### PR TITLE
[BUG] Adding case in free() function to avoid pointer undefined 

### DIFF
--- a/src/libsparse3d/MR3D_Obj.cc
+++ b/src/libsparse3d/MR3D_Obj.cc
@@ -849,14 +849,27 @@ void MR_3D::free ()
     Border = DEFAULT_BORDER_3D;
     switch (Set_Transform)
     {
-     case TRANS3_MALLAT:
-         Data.free();
+    case TRANS3_MALLAT:
+        Data.free();
         break;
-     case  TRANS3_PAVE:
-         AT3D_WT.free(TabBand, Nbr_Plan);
-       break;
-     default: cerr << "Error: bad transform ... " << endl;
-              exit(-1);
+    case TRANS3_PAVE:
+        AT3D_WT.free(TabBand, Nbr_Plan);
+        break;
+    case S3_UNDEFINED:
+        // We set those attrributes to NULL because these should be instantiated
+        // in the init().
+        TabPosX = NULL;
+        TabSizeNx = NULL;
+        TabPosY = NULL;
+        TabSizeNy = NULL;
+        TabPosZ = NULL;
+        TabSizeNz = NULL;
+        FilterBank = NULL;
+        break;
+
+    default: cerr << "Error: bad transform ... " << endl;
+        exit(-1);
+
     }
     Nbr_Plan = 0;
     Nbr_Band = 0;


### PR DESCRIPTION
When the destructor was called over a MR3D obj in which Set_Transform was set to undefined (can happen if you create the object with initializing it but not allocating memory), there was no case in the switch to handle the issue and the execution broke with a pointer error. 

I've added declaration of object to be destroyed as all others subclasses of MR3D to avoid this bug. 