### PR TITLE
Fix errors reported by Clang

### DIFF
--- a/src/libsparse1d/Filter.cc
+++ b/src/libsparse1d/Filter.cc
@@ -84,8 +84,8 @@ static float   AntoniniAnalysis[] =  {  3.782845550699535e-02,
 			     -2.384946501937986e-02,
 			      3.782845550699535e-02 };
 			      
-const float  SQRT2 = sqrt(2.);
-static float HaarCoeffs [3] = {1./SQRT2, 1./SQRT2, 0};
+const float  SQRT2 = sqrt(2.0f);
+static float HaarCoeffs [3] = {1.0f/SQRT2, 1.0f/SQRT2, 0.0f};
 
 static float Daub4Coeffs [7] = {0,0,0,
                                  0.4829629131445341,  

--- a/src/libtools/IM_Edge.cc
+++ b/src/libtools/IM_Edge.cc
@@ -50,7 +50,7 @@ static float Prewittr[3][3] = { {1,0,-1}, {1,0,-1}, {1,0,-1}};
 static float Prewittc[3][3] = { {-1,-1,-1}, {0,0,0}, {1,1,1}};
 #define NORM_PREWITT 1./3.
 
-#define S2 sqrt(2.)
+#define S2 sqrt(2.0f)
 static float FreiChenr[3][3] = { {1,0,-1}, {S2,0,-S2}, {1,0,-1}};
 static float FreiChenc[3][3] = { {-1,-S2,-1}, {0,0,0}, {1,S2,1}};
 #define NORM_FREICHEN 1./(2+S2)


### PR DESCRIPTION
Use `float` literals to initialise `float` arrays.