### PR TITLE
Fvector fix

### DIFF
--- a/src/libtools/NR_nrutil.cc
+++ b/src/libtools/NR_nrutil.cc
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "NR.h"
- 
+
 #define NR_END 1
 
 void nrerror(const char error_text[])
@@ -17,7 +17,7 @@ void nrerror(const char error_text[])
 
 
 
-float *vector(int nl,int nh)
+float *fvector(int nl,int nh)
 {
 	float *v;
 
@@ -231,4 +231,3 @@ unsigned long *lvector(long nl,long  nh)
 	if (!v) nrerror("allocation failure in lvector()");
 	return v-nl+NR_END;
 }
-

--- a/src/libtools/NR_util.h
+++ b/src/libtools/NR_util.h
@@ -9,14 +9,14 @@
 **    Author: C. Delattre & R. Gastaud
 **
 **    Date:  98/05/12
-**    
+**
 **    File:  NR_util.h
 **
 *******************************************************************************
 **
 **    DESCRIPTION  Definition of the numerical recipies memory  allocation
 **    -----------  and deallocation routine.
-**              
+**
 ******************************************************************************/
 
 
@@ -24,7 +24,7 @@
 #define _UTIL_H
 
 void nrerror(const char error_text[]);
-float *vector(int nl,int nh);
+float *fvector(int nl,int nh);
 int *ivector(int nl,int nh);
 double *dvector(int nl,int nh);
 float **matrix(int nrl,int nrh,int ncl,int nch);


### PR DESCRIPTION
## Summary

- Updated `vector` to `fvector` in `NR_util.h` and `NR_nrutil.cc` to avoid conflicts with `std::vector` 