### PR TITLE
Build option for Inpainting binaries

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -55,7 +55,7 @@ jobs:
           mkdir build
           cd build
           cmake .. --log-level=VERBOSE
-          make
+          make -j 4
 
       - name: Run Unit Tests
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,13 @@ if(USE_FFTW)
 
 endif()
 
+if(BUILD_MR)
+
+	# Locate GSL
+	find_pkg(GSL gsl)
+
+endif()
+
 if(BUILD_MRS)
 
 	# Locate HEALPix

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if(
 	"${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang"
 	AND NOT "${CMAKE_CXX_COMPILER}" MATCHES "Homebrew"
 )
-  find_package(BigMac 0.0.5 REQUIRED)
+  find_package(BigMac 0.0.6 REQUIRED)
 endif()
 
 # Locate OpenMP

--- a/README.md
+++ b/README.md
@@ -100,13 +100,18 @@ In order to build Sparse2D from source, you will need to ensure you have install
 
 #### Optional
 
-   - [Armadillo](https://arma.sourceforge.net/) (not required if `ONLY_SPARSE=ON`)
-   - [FFTW](https://www.fftw.org/) (not required if `USE_FFTW=OFF`)
+   - [Armadillo](https://arma.sourceforge.net/)
+     (not required if `ONLY_SPARSE=ON` or `ONLY_INPAINT=ON`)
+   - [FFTW](https://www.fftw.org/)
+     (not required if `ONLY_SPARSE=ON` and `USE_FFTW=OFF`)
    - [GSL](https://www.gnu.org/software/gsl/) (not required if `ONLY_SPARSE=ON`)
-   - [HEALPix](https://healpix.sourceforge.io/) (not required if `ONLY_SPARSE=ON`)
+   - [HEALPix](https://healpix.sourceforge.io/)
+     (not required if `ONLY_SPARSE=ON` or `ONLY_INPAINT=ON`)
    - [libomp](https://openmp.llvm.org/) (only required if using macOS `clang`)
-   - [Pybind11](https://pybind11.readthedocs.io/) (not required if `BUILD_PYBIND=OFF`)
-   - [Python](https://www.python.org/) (not required if `BUILD_PYBIND=OFF`)
+   - [Pybind11](https://pybind11.readthedocs.io/)
+     (not required if `BUILD_PYBIND=OFF` or `ONLY_INPAINT=ON`)
+   - [Python](https://www.python.org/)
+     (not required if `BUILD_PYBIND=OFF` or `ONLY_INPAINT=ON`)
 
 ### Full Sparse2D build
 
@@ -128,6 +133,10 @@ make
 make install
 ```
 
+> Tip: You can significantly increase the speed of compilation by using the
+> `--jobs` (or `-j`) option for `make`, which builds the targets in parallel.
+> For example, to use 8 cores you would run `make -j 8`.
+
 ### Build options
 
 Sparse2D supports the following CMake build options:
@@ -144,7 +153,8 @@ Sparse2D supports the following CMake build options:
 - `BUILD_ASTRO_GAL` (default `ON`): Build the ASTRO_GAL package
 - `BUILD_PYBIND` (default `ON`): Build Python bindings
 - `ONLY_SPARSE` (default `OFF`): Only build the SPARSE package
-- `USE_FFTW` (default `ON`): Use FFTW libraries
+- `ONLY_INPAINT` (default `OFF`): Only build the packages required for inpainting
+- `USE_FFTW` (default `ON`): Use FFTW libraries (optional for sparse package only)
 - `BUILD_CFITSIO` (default `OFF`): Build CFITSIO from source
 - `BUILD_FFTW3` (default `OFF`): BUILD FFTW3 from source
 - `BUILD_HEALPIX` (default `OFF`): BUILD HEALPix from source

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ In order to build Sparse2D from source, you will need to ensure you have install
 
    - [Armadillo](https://arma.sourceforge.net/)
      (not required if `ONLY_SPARSE=ON` or `ONLY_INPAINT=ON`)
+   - [BigMac](https://github.com/sfarrens/bigmac)
+     (only required if using macOS `clang`)(>= v0.0.6)
    - [FFTW](https://www.fftw.org/)
      (not required if `ONLY_SPARSE=ON` and `USE_FFTW=OFF`)
    - [GSL](https://www.gnu.org/software/gsl/) (not required if `ONLY_SPARSE=ON`)

--- a/cmake/BuildOptions.cmake
+++ b/cmake/BuildOptions.cmake
@@ -24,7 +24,8 @@ option(BUILD_ASTRO_WL "BUILD_ASTRO_WL" ON)    # Build the ASTRO_WL package
 option(BUILD_ASTRO_GAL "BUILD_ASTRO_GAL" ON)  # Build the ASTRO_GAL package
 option(BUILD_PYBIND "BUILD_PYBIND" ON)        # Build Python bindings
 option(ONLY_SPARSE "ONLY_SPARSE" OFF)         # Only build the SPARSE package
-option(USE_FFTW "USE_FFTW" ON)                # Use FFTW libraries
+option(ONLY_INPAINT "ONLY_INPAINT" OFF)       # Only build the packages required for inpainting
+option(USE_FFTW "USE_FFTW" ON)                # Use FFTW libraries (optional for sparse package only)
 option(BUILD_CFITSIO "BUILD_CFITSIO" OFF)     # Build CFITSIO from source
 option(BUILD_FFTW3 "BUILD_FFTW3" OFF)         # BUILD FFTW3 from source
 option(BUILD_HEALPIX "BUILD_HEALPIX" OFF)     # BUILD HEALPix from source
@@ -43,6 +44,17 @@ if(ONLY_SPARSE)
   set(BUILD_MRS OFF)
   set(BUILD_ASTRO_WL OFF)
   set(BUILD_ASTRO_GAL OFF)
+endif()
+
+# If ONLY_INPAINT is set disable additional builds
+if(ONLY_INPAINT)
+  set(BUILD_MSVST OFF)
+  set(BUILD_MWIR OFF)
+  set(BUILD_DICLEARN OFF)
+  set(BUILD_MRS OFF)
+  set(BUILD_ASTRO_WL OFF)
+  set(BUILD_ASTRO_GAL OFF)
+  set(BUILD_PYBIND OFF)
 endif()
 
 # If BUILD_DEPS is set build all dependencies from source
@@ -107,6 +119,7 @@ message(VERBOSE "  BUILD_ASTRO_WL: ${BUILD_ASTRO_WL}")
 message(VERBOSE "  BUILD_ASTRO_GAL: ${BUILD_ASTRO_GAL}")
 message(VERBOSE "  BUILD_PYBIND: ${BUILD_PYBIND}")
 message(VERBOSE "  ONLY_SPARSE: ${ONLY_SPARSE}")
+message(VERBOSE "  ONLY_INPAINT: ${ONLY_INPAINT}")
 message(VERBOSE "  USE_FFTW: ${USE_FFTW}")
 message(VERBOSE "  BUILD_CFITSIO: ${BUILD_CFITSIO}")
 message(VERBOSE "  BUILD_FFTW3: ${BUILD_FFTW3}")


### PR DESCRIPTION
- Added `ONLY_INPAINT` option to build only the libraries and binaries required for inpainting.
- Updated minimum BigMac version required for macOS source build.
- Updated README.md