### PR TITLE
Fetch commands for Pybind11

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,20 +26,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-
-      - name: Set up Conda with Python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-          auto-activate-base: false
-          activate-environment: sparse2d
 
-      - name: Check Conda
-        run: |
-          conda info
-          conda list
-          python --version
+      - name: Check Python Version
+        run: python --version
 
       - name: Install macOS Dependencies
         if: runner.os == 'macOS'
@@ -65,11 +58,6 @@ jobs:
           cmake -Bbuild -H. -DBUILD_TESTING=OFF
           sudo cmake --build build/ --target install
           cd
-
-      - name: Install Python Dependencies
-        run: |
-          pip install pybind11
-          pip show pybind11
 
       - name: Compile Sparse2D Binaries
         run: |
@@ -104,13 +92,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Conda with Python ${{ matrix.python-version }}
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
         with:
-          auto-update-conda: true
           python-version: ${{ matrix.python-version }}
-          auto-activate-base: false
-          activate-environment: sparse2d
+
+      - name: Check Python Version
+        run: python --version
 
       - name: Install Linux Dependencies
         run: |
@@ -124,11 +112,6 @@ jobs:
           cmake -Bbuild -H. -DBUILD_TESTING=OFF
           sudo cmake --build build/ --target install
           cd
-
-      - name: Install Python Dependencies
-        run: |
-          pip install pybind11
-          pip show pybind11
 
       - name: Compile Sparse2D Binaries
         run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,13 +18,9 @@ jobs:
         os: [macos-latest, ubuntu-latest]
         python-version: ["3.10"]
 
-    defaults:
-      run:
-        shell: bash -el {0}
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
 # Load CMake tools
 include(ExternalProject)
+include(FetchContent)
 include(FindPkgConfig)
 
 # Load custom CMake functions: find_pkg, build_package, build_pybind
@@ -52,6 +53,19 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_BINARY_DIR}/lib")
 # ----------------- #
 # Find Dependencies #
 # ----------------- #
+
+if(BUILD_PYBIND)
+
+	# Locate Python
+	set(Python_FIND_STRATEGY LOCATION)
+	find_package(Python COMPONENTS Interpreter Development)
+	include_directories(${Python_INCLUDE_DIRS})
+	link_directories(${Python_LIBRARY_DIRS})
+
+	# Source Pybind11
+	include(FetchPybind11)
+
+endif()
 
 # Use BigMac for local clang build
 if(
@@ -99,38 +113,6 @@ if(BUILD_DICLEARN)
 	# Locate Armadillo
 	find_package(Armadillo)
 	include_directories(${ARMADILLO_INCLUDE_DIRS})
-
-endif()
-
-if(BUILD_PYBIND)
-
-	# Locate Python
-	set(Python_FIND_STRATEGY LOCATION)
-	find_package(Python COMPONENTS Interpreter Development)
-	include_directories(${Python_INCLUDE_DIRS})
-	link_directories(${Python_LIBRARY_DIRS})
-
-	# Allow CMake to check the current Python environment for Pybind11
-	set(pybind11_cmake_path "/python*/*-packages/pybind11/share/*/*")
-	file(
-		GLOB
-		pybind11_path_list
-		"${Python_LIBRARY_DIRS}${pybind11_cmake_path}"
-		"/usr/local/lib${pybind11_cmake_path}"
-		"/home/runner/.local/lib${pybind11_cmake_path}"
-	)
-	if(pybind11_path_list)
-		list(GET pybind11_path_list 0 pybind11_DIR)
-	endif()
-
-	# Locate Pybind11
-	find_package(pybind11 REQUIRED)
-	include_directories(${pybind11_INCLUDE_DIR})
-
-	# Set default install path for bindings
-	if(NOT DEFINED PYBIND_INSTALL_PATH)
-		set(PYBIND_INSTALL_PATH "python")
-	endif()
 
 endif()
 

--- a/cmake/BuildPybind.cmake
+++ b/cmake/BuildPybind.cmake
@@ -39,7 +39,7 @@ function(build_pybind_target target libs)
   add_library(${tarname} SHARED ${target})
 
   # Link libraries to target
-  target_link_libraries(${tarname} "${libs}" OpenMP::OpenMP_CXX pybind11::module pybind11::lto pybind11::windows_extras)
+  target_link_libraries(${tarname} "${libs}" OpenMP::OpenMP_CXX pybind11::headers)
 
   # Set system dependend properties
   if(APPLE)

--- a/cmake/FetchPybind11.cmake
+++ b/cmake/FetchPybind11.cmake
@@ -1,0 +1,21 @@
+# -------------- #
+# Fetch Pybind11 #
+# -------------- #
+
+# Set Pybind11 Version
+set(Pybind11Version 2.10.3)
+set(Pybind11SHA256 5d8c4c5dda428d3a944ba3d2a5212cb988c2fae4670d58075a5a49075a6ca315)
+
+# Set Pybdin11 fetch location
+FetchContent_Declare(
+    pybind11
+    URL  https://github.com/pybind/pybind11/archive/refs/tags/v${Pybind11Version}.tar.gz
+    URL_HASH  SHA256=${Pybind11SHA256}
+)
+
+# Fetch and source Pybind11
+FetchContent_GetProperties(pybind11)
+if(NOT pybind11_POPULATED)
+    FetchContent_Populate(pybind11)
+    add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
+endif()


### PR DESCRIPTION
- CMake now fetches a set version of Pybind11 and uses this for building Python bindings
- CI updates to avoid using Conda