### PR TITLE
MSVST code update by NOA

### DIFF
--- a/src/msvst/msvstmain/msvst_2d1d.cc
+++ b/src/msvst/msvstmain/msvst_2d1d.cc
@@ -355,7 +355,7 @@ void bandDenoise(fltarray &band, double sigma, to_array<SUPTYPE, true> *ms, int 
     {
         pr = ws.gaussHardThreshold(band, PROBA[PROGMODE], sigma, ms);
         if (VERBOSE)
-	      cerr << "(scalexy, scalez) = (" << sxy << ", " << sz << ") cut-off p-value = " << setprecision(6) << pr << endl;                 
+	      cout << "(scalexy, scalez) = (" << sxy << ", " << sz << ") cut-off p-value = " << setprecision(6) << pr << endl;                 
         if (WRITESNR)
         {
               sprintf(snr_filename, "%s_XY%d_Z%d.fits", Name_Imag_SNR, sxy, sz);
@@ -372,7 +372,7 @@ void bandDenoise(fltarray &band, double sigma, to_array<SUPTYPE, true> *ms, int 
     {
         fdrp = ws.gaussFDRThreshold(band, sigma, PROBA[PROGMODE], FDRINDEP, ms);
         if (VERBOSE)
-          cerr << "(scalexy, scalez) = (" << sxy << ", " << sz << ") cut-off p-value = " << setprecision(6) << fdrp << endl;                 
+          cout << "(scalexy, scalez) = (" << sxy << ", " << sz << ") cut-off p-value = " << setprecision(6) << fdrp << endl;                 
         if (WRITESNR)
         {
               sprintf(snr_filename, "%s_XY%d_Z%d.fits", Name_Imag_SNR, sxy, sz);
@@ -405,7 +405,7 @@ void b3SplineDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup)
     fltarray *ddxyz = new fltarray;
     fltarray *temp = new fltarray;
     
-    if (VERBOSE) cerr << "Atrous transform ... " << endl;
+    if (VERBOSE) cout << "Atrous transform ... " << endl;
 
     // create the ccpxyz of sxy = 0
     *temp = data;
@@ -572,7 +572,7 @@ void multiSupIter (fltarray &origdata, fltarray &solution, fltarray *model, flta
   for (int i=0; i<niter; i++)
   {
       int s = 0;
-      if (VERBOSE) cerr << "Iteration = " << (i+1) << " ... " << endl;
+      if (VERBOSE) cout << "Iteration = " << (i+1) << " ... " << endl;
       *tempd = origdata;
       if (MODELIM) *tempd -= *model;
       
@@ -698,16 +698,16 @@ void denoise (fltarray &data, fltarray *model)
  	fltarray *multiSup = new fltarray[NSCALEXY*(NSCALEZ+1) + NSCALEZ];
 
 	if (VERBOSE)
-	  cerr << "Initial denoising ... " << endl;
+	  cout << "Initial denoising ... " << endl;
 	  
     b3SplineDenoise<float>(data, multiSup);
 	data = *origData;
 	
 	if (VERBOSE)
-	  cerr << "Entering into the iterative denoising ..." << endl;
+	  cout << "Entering into the iterative denoising ..." << endl;
     multiSupIter (*origData, data, model, multiSup, NITER);
 	if (VERBOSE)
-	  cerr << "Iteration complete." << endl;
+	  cout << "Iteration complete." << endl;
 
 	delete origData; origData = NULL; 
     delete [] multiSup; multiSup = NULL;
@@ -784,10 +784,10 @@ int main(int argc, char *argv[])
 	   denoise(*data, model);
 
        if (VERBOSE)
-    	   cerr << "Writing denoising result file ... " << endl;
+    	   cout << "Writing denoising result file ... " << endl;
        fits_write_fltarr(Name_Imag_Out, *data, &header);
        if (VERBOSE)
-    	 cerr << "Writing complete." << endl;
+    	 cout << "Writing complete." << endl;
 
        if (MODELIM)
        {

--- a/src/msvst/msvstmain/msvst_iwt2d.cc
+++ b/src/msvst/msvstmain/msvst_iwt2d.cc
@@ -331,21 +331,21 @@ void b3SplineDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup)
 		{
           // sigma = l2 norm of Id-B3 filter
 		  if (VERBOSE)
-              cerr << "Var = " << Utils<double>::b3VSTSepCoefVar (dim, s) << endl;
+              cout << "Var = " << Utils<double>::b3VSTSepCoefVar (dim, s) << endl;
           pr = ws.gaussHardThreshold(*cg, PROBA[PROGMODE], 
                                      sqrt(Utils<double>::b3VSTSepCoefVar (dim, s)), 
                                      ms ? &multiSup[s-1] : NULL);
 		  if (VERBOSE)
-		    cerr << "scale = " << s << " cut-off p-value = " << setprecision(6) << pr << endl;                 
+		    cout << "scale = " << s << " cut-off p-value = " << setprecision(6) << pr << endl;                 
         }
 		else if (PROGMODE == FDR)
 		{
 		  if (VERBOSE)
-              cerr << "Var = " << Utils<double>::b3VSTSepCoefVar (dim, s) << endl;
+              cout << "Var = " << Utils<double>::b3VSTSepCoefVar (dim, s) << endl;
           fdrp = ws.gaussFDRThreshold(*cg, sqrt(Utils<double>::b3VSTSepCoefVar (dim, s)), 
                                       PROBA[PROGMODE], FDRINDEP, ms ? &multiSup[s-1] : NULL);
 		  if (VERBOSE)
-		    cerr << "scale = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;                 
+		    cout << "scale = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;                 
         }
 	}
     
@@ -410,7 +410,7 @@ void multiSupIter (fltarray &origdata, fltarray &solution, fltarray *multiSup, i
 
   for (int i=0; i<niter; i++)
   {
-      if (VERBOSE) cerr << "Iteration = " << (i+1) << " ... " << endl;
+      if (VERBOSE) cout << "Iteration = " << (i+1) << " ... " << endl;
       *tempd = origdata;
       
 	  for (int s=1; s<=NSCALE; s++)
@@ -455,7 +455,7 @@ void denoise (fltarray &data)
     }
 
 	if (VERBOSE)
-	  cerr << "Initial denoising ... " << endl;
+	  cout << "Initial denoising ... " << endl;
 	  
     b3SplineDenoise<float>(data, multiSup);
     data = *origData;
@@ -463,10 +463,10 @@ void denoise (fltarray &data)
     if (NITER > 1)
     {
     	if (VERBOSE)
-	       cerr << "Entering into the iterative denoising ..." << endl;
+	       cout << "Entering into the iterative denoising ..." << endl;
         multiSupIter (*origData, data, multiSup, NITER);
 	    if (VERBOSE)
-	       cerr << "Iteration complete." << endl;
+	       cout << "Iteration complete." << endl;
     }
     
 	delete origData; origData = NULL; 
@@ -543,10 +543,10 @@ int main(int argc, char *argv[])
 	   denoise(*data);
 
        if (VERBOSE)
-    	   cerr << "Writing denoising result file ... " << endl;
+    	   cout << "Writing denoising result file ... " << endl;
        fits_write_fltarr(Name_Imag_Out, *data, &header);
        if (VERBOSE)
-    	 cerr << "Writing complete." << endl;
+    	 cout << "Writing complete." << endl;
 
        delete data; data = NULL; 
    }

--- a/src/msvst/msvstmain/msvst_iwt2d_coupled.cc
+++ b/src/msvst/msvstmain/msvst_iwt2d_coupled.cc
@@ -365,12 +365,12 @@ void b3SplineDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup)
 		{
           // sigma = l2 norm of Id-B3 filter
 		  if (VERBOSE)
-              cerr << "Var = " << Utils<double>::b3VSTCoefVar (dim, s) << endl;
+              cout << "Var = " << Utils<double>::b3VSTCoefVar (dim, s) << endl;
           pr = ws.gaussHardThreshold(cg[s-1], PROBA[PROGMODE], 
                                      sqrt(Utils<double>::b3VSTCoefVar (dim, s)), 
                                      ms ? &multiSup[s-1] : NULL);
 		  if (VERBOSE)
-		    cerr << "scale = " << s << " cut-off p-value = " << setprecision(6) << pr << endl;                 
+		    cout << "scale = " << s << " cut-off p-value = " << setprecision(6) << pr << endl;                 
 		  
           if (WRITESNR)
           {
@@ -388,11 +388,11 @@ void b3SplineDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup)
 		else if (PROGMODE == FDR)
 		{
 		  if (VERBOSE)
-              cerr << "Var = " << Utils<double>::b3VSTCoefVar (dim, s) << endl;
+              cout << "Var = " << Utils<double>::b3VSTCoefVar (dim, s) << endl;
           fdrp = ws.gaussFDRThreshold(cg[s-1], sqrt(Utils<double>::b3VSTCoefVar (dim, s)), 
                                       PROBA[PROGMODE], FDRINDEP, ms ? &multiSup[s-1] : NULL);
 		  if (VERBOSE)
-		    cerr << "scale = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;                 
+		    cout << "scale = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;                 
 
           if (WRITESNR)
           {
@@ -478,7 +478,7 @@ void multiSupIter (fltarray &origdata, fltarray &solution, fltarray *model, flta
 
   for (int i=0; i<niter; i++)
   {
-      if (VERBOSE) cerr << "Iteration = " << (i+1) << " ... " << endl;
+      if (VERBOSE) cout << "Iteration = " << (i+1) << " ... " << endl;
       *tempd = origdata;
       if (MODELIM) *tempd -= *model;
       
@@ -533,7 +533,7 @@ void denoise (fltarray &data, fltarray *model)
     }
 
 	if (VERBOSE)
-	  cerr << "Initial denoising ... " << endl;
+	  cout << "Initial denoising ... " << endl;
 
 	fltarray *modelbk = NULL;
 	if (MODELIM)
@@ -548,10 +548,10 @@ void denoise (fltarray &data, fltarray *model)
     if (NITER > 1)
     {
     	if (VERBOSE)
-	       cerr << "Entering into the iterative denoising ..." << endl;
+	       cout << "Entering into the iterative denoising ..." << endl;
         multiSupIter (*origData, data, modelbk, multiSup, NITER);
 	    if (VERBOSE)
-	       cerr << "Iteration complete." << endl;
+	       cout << "Iteration complete." << endl;
     }
     else
     {
@@ -645,10 +645,10 @@ int main(int argc, char *argv[])
 	   denoise(*data, model);
 
        if (VERBOSE)
-    	   cerr << "Writing denoising result file ... " << endl;
+    	   cout << "Writing denoising result file ... " << endl;
        fits_write_fltarr(Name_Imag_Out, *data, &header);
        if (VERBOSE)
-    	 cerr << "Writing complete." << endl;
+    	 cout << "Writing complete." << endl;
 
        delete data; data = NULL; 
        if (MODELIM)

--- a/src/msvst/msvstmain/msvst_uwt2d.cc
+++ b/src/msvst/msvstmain/msvst_uwt2d.cc
@@ -485,7 +485,7 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 
     if ((PROGMODE==ANSC || PROGMODE == FISZ) && dim == 1)
 	{
-	    if (VERBOSE) cerr << "Wavelet transform 1D ... " << endl;
+	    if (VERBOSE) cout << "Wavelet transform 1D ... " << endl;
 		fltarray *ch = new fltarray;
 		fltarray *cg = new fltarray[NSCALE];
 		for (int s=1; s<=NSCALE; s++)
@@ -494,7 +494,7 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 			mwirWT->transform1D(data, *ch, cg[s-1], s, dec[0]);
 			data = *ch;
 		}
-		if (VERBOSE) cerr << "Transform complete." << endl << "Wavelet thresholding ... " << endl;
+		if (VERBOSE) cout << "Transform complete." << endl << "Wavelet thresholding ... " << endl;
 		
 		for (int s=NSCALE; s>=1; s--)
 		{
@@ -525,7 +525,7 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 			  }	  		  
 
 			  if (VERBOSE)
-			    cerr << "scale = " << s << " cut-off p-value = " << setprecision(6) << (FDRTHRESH ? fdrp : pr) << endl;
+			    cout << "scale = " << s << " cut-off p-value = " << setprecision(6) << (FDRTHRESH ? fdrp : pr) << endl;
 			}
 			mwirWT->reconstruction1D(*ch, cg[s-1], data, s, dec[0]);
 			extractData(data, ext[s-1]);
@@ -533,11 +533,11 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 		}
 		delete ch; delete [] cg; 
 		ch = NULL; cg = NULL; 
-		if (VERBOSE) cerr << "Thresholding complete." << endl;
+		if (VERBOSE) cout << "Thresholding complete." << endl;
 	}
 	else if ((PROGMODE==ANSC || PROGMODE == FISZ) && dim == 2)
 	{
-	    if (VERBOSE) cerr << "Wavelet transform 2D ... " << endl;
+	    if (VERBOSE) cout << "Wavelet transform 2D ... " << endl;
 		fltarray *chh = new fltarray;
 		fltarray *chg = new fltarray[NSCALE];
 		fltarray *cgh = new fltarray[NSCALE];
@@ -548,7 +548,7 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 			mwirWT->transform2D(data, *chh, chg[s-1], cgh[s-1], cgg[s-1], s, dec);
 			data = *chh;
 		}
-		if (VERBOSE) cerr << "Transform complete." << endl << "Wavelet thresholding ... " << endl;
+		if (VERBOSE) cout << "Transform complete." << endl << "Wavelet thresholding ... " << endl;
 
 		for (int s=NSCALE; s>=1; s--)
 		{
@@ -575,13 +575,13 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 			        {
 			    	    fdrp = ws.gaussFDRThreshold (chg[s-1], stdhg, pr, FDRINDEP, &multiSup[3*(s-1)]);
 	  			        if (VERBOSE)
-			   		       cerr << "scale(hg) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
+			   		       cout << "scale(hg) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
 			    	    fdrp = ws.gaussFDRThreshold (cgh[s-1], stdgh, pr, FDRINDEP, &multiSup[3*(s-1)+1]);
 	  			        if (VERBOSE)
-			   		       cerr << "scale(gh) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
+			   		       cout << "scale(gh) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
 			    	    fdrp = ws.gaussFDRThreshold (cgg[s-1], stdgg, pr, FDRINDEP, &multiSup[3*(s-1)+2]);
 	  			        if (VERBOSE)
-			   		       cerr << "scale(gg) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
+			   		       cout << "scale(gg) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
 			    	}
 			        else
 			        {	
@@ -589,7 +589,7 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 				      pr = ws.gaussHardThreshold(cgh[s-1], pr, stdgh, &multiSup[3*(s-1)+1]);
 				      pr = ws.gaussHardThreshold(cgg[s-1], pr, stdgg, &multiSup[3*(s-1)+2]);				
 		  		      if (VERBOSE)
-				    	cerr << "scale = " << s << " cut-off p-value = " << setprecision(6) << pr << endl;
+				    	cout << "scale = " << s << " cut-off p-value = " << setprecision(6) << pr << endl;
 				    }
 			  }
 			  else
@@ -598,13 +598,13 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 			        {
 			    	    fdrp = ws.gaussFDRThreshold (chg[s-1], stdhg, pr, FDRINDEP);
 	  			        if (VERBOSE)
-			   		       cerr << "scale(hg) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
+			   		       cout << "scale(hg) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
 			    	    fdrp = ws.gaussFDRThreshold (cgh[s-1], stdgh, pr, FDRINDEP);
     	  			    if (VERBOSE)
-			   		       cerr << "scale(gh) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
+			   		       cout << "scale(gh) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
 			    	    fdrp = ws.gaussFDRThreshold (cgg[s-1], stdgg, pr, FDRINDEP);
 	  			        if (VERBOSE)
-			   		       cerr << "scale(gg) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
+			   		       cout << "scale(gg) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
 			    	}
 			        else
 			        {	
@@ -612,7 +612,7 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 				      pr = ws.gaussHardThreshold(cgh[s-1], pr, stdgh);
 				      pr = ws.gaussHardThreshold(cgg[s-1], pr, stdgg);				
 				      if (VERBOSE)
-				    	cerr << "scale = " << s << " cut-off p-value = " << setprecision(6) << pr << endl;
+				    	cout << "scale = " << s << " cut-off p-value = " << setprecision(6) << pr << endl;
 				    }
 			  }
 			}
@@ -622,11 +622,11 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 		}
 		delete chh; delete [] chg; delete [] cgh; delete [] cgg;
 		chh = NULL; chg = NULL; cgh = NULL; cgg = NULL;
-		if (VERBOSE) cerr << "Thresholding complete." << endl;
+		if (VERBOSE) cout << "Thresholding complete." << endl;
 	}
     else if ((PROGMODE == MSVST) && (dim == 1))
     {
-	    if (VERBOSE) cerr << "Wavelet transform 1D ... " << endl;	    
+	    if (VERBOSE) cout << "Wavelet transform 1D ... " << endl;	    
 	    fltarray *vstData = new fltarray;
 		fltarray *chvst = new fltarray, *ch = new fltarray;
 		fltarray *cg = new fltarray[NSCALE];
@@ -653,7 +653,7 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 				   ws.gaussHardThreshold(cg[s-1], PROBA[0], stdg, &multiSup[s-1]);
 			    }
 			  if (VERBOSE)
-			    cerr << "scale = " << s << " cut-off p-value = " << setprecision(6) << PROBA[0] << endl;
+			    cout << "scale = " << s << " cut-off p-value = " << setprecision(6) << PROBA[0] << endl;
 			}
 			else if (FDRTHRESH)
 			{
@@ -661,7 +661,7 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 			    {
 				fdrp = ws.gaussFDRThreshold(cg[s-1], stdg, PROBA[1], FDRINDEP, &multiSup[s-1]);
 				if (VERBOSE)
-				  cerr << "scale (g) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
+				  cout << "scale (g) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
 			    }
             }
 		}
@@ -670,7 +670,7 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
     }    
 	else if ((PROGMODE == MSVST) && (dim == 2))
 	{
-	    if (VERBOSE) cerr << "Wavelet transform 2D ... " << endl;
+	    if (VERBOSE) cout << "Wavelet transform 2D ... " << endl;
 	    fltarray *vstData = new fltarray;
 		fltarray *chhvst = new fltarray, *chh = new fltarray;
 		fltarray *chg = new fltarray[NSCALE], \
@@ -704,7 +704,7 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 				ws.gaussHardThreshold(cgg[s-1], PROBA[0], stdgg, &multiSup[3*(s-1)+2]);
 			    }
 			  if (VERBOSE)
-			    cerr << "scale = " << s << " cut-off p-value = " << setprecision(6) << PROBA[0] << endl;
+			    cout << "scale = " << s << " cut-off p-value = " << setprecision(6) << PROBA[0] << endl;
 			}
 			else if (FDRTHRESH)
 			{
@@ -712,20 +712,20 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 			    {
 				fdrp = ws.gaussFDRThreshold(chg[s-1], stdhg, PROBA[1], FDRINDEP, &multiSup[3*(s-1)]);
 				if (VERBOSE)
-				  cerr << "scale (hg) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
+				  cout << "scale (hg) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
 				fdrp = ws.gaussFDRThreshold(cgh[s-1], stdgh, PROBA[1], FDRINDEP, &multiSup[3*(s-1)+1]);
 				if (VERBOSE)
-				  cerr << "scale (gh) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
+				  cout << "scale (gh) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
 				fdrp = ws.gaussFDRThreshold(cgg[s-1], stdgg, PROBA[1], FDRINDEP, &multiSup[3*(s-1)+2]);
 				if (VERBOSE)
-				  cerr << "scale (gg) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
+				  cout << "scale (gg) = " << s << " cut-off p-value = " << setprecision(6) << fdrp << endl;
 			    }
             }
 		}
 		delete chh; delete [] chg; delete [] cgh; delete [] cgg; delete chhvst; delete vstData;
 		chh = NULL; chg = NULL; cgh = NULL; cgg = NULL; chhvst = NULL; vstData = NULL;
 	}
-	if (VERBOSE) cerr << "Thresholding complete." << endl;
+	if (VERBOSE) cout << "Thresholding complete." << endl;
 	delete mwirWT; mwirWT = NULL;
 }
 
@@ -753,10 +753,10 @@ void anscombeDenoise (fltarray &data)
   
   // Anscombe transform
   if (VERBOSE)
-    cerr << "Anscombe transform ... " << endl;
+    cout << "Anscombe transform ... " << endl;
   Utils<float>::anscombeTransform(data);	
   if (VERBOSE)
-    cerr << "Anscombe transform complete. " << endl;
+    cout << "Anscombe transform complete. " << endl;
 	
   // denoising and restoration
   waveletDenoise<float>(data, sbf, DEC);
@@ -784,7 +784,7 @@ void fiszDenoise (fltarray &data, int DX, int DY, int DZ)
 	for (int tx=-dx; tx<=dx; tx++)
 	{
 	  if (VERBOSE)
-	    cerr << "Cycle transition : tx = " << tx << " ty = " << ty << " tz = " << tz << endl;
+	    cout << "Cycle transition : tx = " << tx << " ty = " << ty << " tz = " << tz << endl;
 		cycleTrans (data, tx, ty, tz);
 	
 		// data extension to do the fisz transform
@@ -799,7 +799,7 @@ void fiszDenoise (fltarray &data, int DX, int DY, int DZ)
         sbf[0].Border = sbf[1].Border = sbf[2].Border = T_BORDER;
 
 		if (VERBOSE)
-		  cerr << "Fisz transform ... " << endl;
+		  cout << "Fisz transform ... " << endl;
 		// Fisz transform
 		if (dim == 1)
 			fisztr.fisz1D(data);
@@ -808,7 +808,7 @@ void fiszDenoise (fltarray &data, int DX, int DY, int DZ)
 		else // dim == 3
 			fisztr.fisz3D(data);
 		if (VERBOSE)
-		  cerr << "Fisz transform complete. " << endl;
+		  cout << "Fisz transform complete. " << endl;
 	
 		// denoising and restoration
 		waveletDenoise<float>(data, sbf, DEC);
@@ -833,14 +833,14 @@ void fiszDenoise (fltarray &data, int DX, int DY, int DZ)
 	}
 	
 	if (VERBOSE)
-	  cerr << " Calculate mean of all the cycle spins ... " << endl;
+	  cout << " Calculate mean of all the cycle spins ... " << endl;
 	if (c != 0)
 	{
 		for (int j=0; j<dlen; j++)
            data(j) = (*sumData)(j) / (float)c;
 	}
 	if (VERBOSE)
-	  cerr << " Calculation complete. " << endl;
+	  cout << " Calculation complete. " << endl;
 
 	// free all the variables	
 	delete origData;  delete sumData;
@@ -907,7 +907,7 @@ void multiSupIter (fltarray &origdata, fltarray &solution, SubBandFilter sbf[], 
 
   for (int i=0; i<niter; i++)
   {
-      if (VERBOSE) cerr << "Iteration = " << (i+1) << " ... " << endl;
+      if (VERBOSE) cout << "Iteration = " << (i+1) << " ... " << endl;
       *tempd = origdata;
       
       if (dim == 1)
@@ -926,7 +926,7 @@ void multiSupIter (fltarray &origdata, fltarray &solution, SubBandFilter sbf[], 
               setConst(*chs, *ch, 0.);    
 	      else
               *chs = *ch; // same approximation band
-		  if (VERBOSE) cerr << "Wavelet transform 1D complete. " << endl << "Wavelet reconstruction ... " << endl;
+		  if (VERBOSE) cout << "Wavelet transform 1D complete. " << endl << "Wavelet reconstruction ... " << endl;
 
 		  for (int s=NSCALE; s>=1; s--)
 		  {
@@ -934,7 +934,7 @@ void multiSupIter (fltarray &origdata, fltarray &solution, SubBandFilter sbf[], 
 		      extractData(solution, ext[s-1]); 
 		      *chs = solution;
 		  }
-		  if (VERBOSE) cerr << "Wavelet reconstruction complete. " << endl;
+		  if (VERBOSE) cout << "Wavelet reconstruction complete. " << endl;
       
           posProject(solution);
           lambda -= delta;
@@ -957,7 +957,7 @@ void multiSupIter (fltarray &origdata, fltarray &solution, SubBandFilter sbf[], 
               setConst(*chhs, *chh, 0.);    
 	      else
               *chhs = *chh; // same approximation band
-		  if (VERBOSE) cerr << "Wavelet transform 2D complete. " << endl << "Wavelet reconstruction ... " << endl;
+		  if (VERBOSE) cout << "Wavelet transform 2D complete. " << endl << "Wavelet reconstruction ... " << endl;
 
 		  for (int s=NSCALE; s>=1; s--)
 		  {
@@ -965,7 +965,7 @@ void multiSupIter (fltarray &origdata, fltarray &solution, SubBandFilter sbf[], 
 		      extractData(solution, ext[s-1]); 
 		      *chhs = solution;
 		  }
-		  if (VERBOSE) cerr << "Wavelet reconstruction complete. " << endl;
+		  if (VERBOSE) cout << "Wavelet reconstruction complete. " << endl;
       
           posProject(solution);
           lambda -= delta;
@@ -1004,7 +1004,7 @@ void denoise (fltarray &data)
     }
 
 	if (VERBOSE)
-	  cerr << "Initial denoising ... " << endl;
+	  cout << "Initial denoising ... " << endl;
 	  
     waveletDenoise<float>(data, sbf, DEC, multiSup);
     data = *origData;
@@ -1012,10 +1012,10 @@ void denoise (fltarray &data)
     if (NITER > 1)
     {
     	if (VERBOSE)
-	       cerr << "Entering into the iterative denoising ..." << endl;
+	       cout << "Entering into the iterative denoising ..." << endl;
         multiSupIter (*origData, data, sbf, DEC, multiSup, NITER);
 	    if (VERBOSE)
-	       cerr << "Iteration complete." << endl;
+	       cout << "Iteration complete." << endl;
     }
     
 	delete origData; origData = NULL; 
@@ -1089,10 +1089,10 @@ int main(int argc, char *argv[])
 	     denoise(*data);
 
        if (VERBOSE)
-    	   cerr << "Writing denoising result file ... " << endl;
+    	   cout << "Writing denoising result file ... " << endl;
        fits_write_fltarr(Name_Imag_Out, *data, &header);
        if (VERBOSE)
-    	 cerr << "Writing complete." << endl;
+    	 cout << "Writing complete." << endl;
 
        delete data; data = NULL; 
    }


### PR DESCRIPTION
In the National Observatory of Athens we have been working, in collaboration with @jstarck, in a source detection pipeline tailored for X-ray transient sources. The 2D+1D MSVST algorithm is a key part of this pipeline. During our development we introduced some changes to the original MSVST code. After discussing the issue with @jstarck, he proposed to include these changes in the official Sparse2D repository.

This pull request includes three changes:

**The user can now select the behavior of the wavelet transform in the borders of the data set.**
The original code always used the I_MIRROR border mode for the wavelet transform. We found out that for our use case a periodic mode worked much better. In this version the user can select between the different modes that were already available in the Borders.h library.

**Modified values for the correction of the detail-detail variance in 2D+1D MSVST**
After extensive testing, we found that the distribution of VST wavelet coefficients could be better reproduced using a different set of variance corrections  in the case of detail-detail coefficients (this values are used in the denoising step). We have implemented the option of using our values instead of the original one.

**Use cout method instead of cerr in verbose mode**
Several messages printed during execution in verbose mode use the cerr method, but they are not error messages. We modified the code to use the cout method in those cases. 

These changes do not modify the default behavior of the code. If the user run the new code with the default options, the output would be as in the current version of MSVST.