### PR TITLE
rename to_array to avoid std conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ endif()
 # ------------------ #
 
 # Set CXX options
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/cmake/FetchPybind11.cmake
+++ b/cmake/FetchPybind11.cmake
@@ -3,8 +3,8 @@
 # -------------- #
 
 # Set Pybind11 Version
-set(Pybind11Version 2.10.3)
-set(Pybind11SHA256 5d8c4c5dda428d3a944ba3d2a5212cb988c2fae4670d58075a5a49075a6ca315)
+set(Pybind11Version 2.13.6)
+set(Pybind11SHA256 e08cb87f4773da97fa7b5f035de8763abc656d87d5773e62f6da0587d1f0ec20)
 
 # Set Pybdin11 fetch location
 FetchContent_Declare(
@@ -16,6 +16,5 @@ FetchContent_Declare(
 # Fetch and source Pybind11
 FetchContent_GetProperties(pybind11)
 if(NOT pybind11_POPULATED)
-    FetchContent_Populate(pybind11)
-    add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
+    FetchContent_MakeAvailable(pybind11)
 endif()

--- a/src/astro_wl/libwl/shearinversions.cc
+++ b/src/astro_wl/libwl/shearinversions.cc
@@ -197,7 +197,7 @@ void ShearInversions::kappa2gamma(double* pt_kappa, double* pt_gamma1, double* p
 
 }
 
-void ShearInversions::kappa2gamma(to_array< double, true >& kappa, to_array< double, true >& gamma1, to_array< double, true >& gamma2)
+void ShearInversions::kappa2gamma(convert_to_array< double, true >& kappa, convert_to_array< double, true >& gamma1, convert_to_array< double, true >& gamma2)
 {
     double *pt_gamma1 = gamma1.buffer();
     double *pt_gamma2 = gamma2.buffer();
@@ -210,7 +210,7 @@ void ShearInversions::kappa2gamma(to_array< double, true >& kappa, to_array< dou
     kappa2gamma(pt_kappa,pt_gamma1,pt_gamma2,Nx,Ny,Nz+1);
 }
 
-void ShearInversions::kappa2flexion(double pixel_size, to_array< double, true >& kappa, to_array< double, true >& F1, to_array< double, true >& F2)
+void ShearInversions::kappa2flexion(double pixel_size, convert_to_array< double, true >& kappa, convert_to_array< double, true >& F1, convert_to_array< double, true >& F2)
 {
     double *pt_F1 = F1.buffer();
     double *pt_F2 = F2.buffer();
@@ -280,7 +280,7 @@ void ShearInversions::kappa2flexion(double pixel_size, double* pt_kappa, double*
 }
 
 
-void ShearInversions::flexion2kappa(double pixel_size,to_array< double, true >& F1, to_array< double, true >& F2, to_array< double, true >& kappa)
+void ShearInversions::flexion2kappa(double pixel_size,convert_to_array< double, true >& F1, convert_to_array< double, true >& F2, convert_to_array< double, true >& kappa)
 {
     double *pt_F1 = F1.buffer();
     double *pt_F2 = F2.buffer();
@@ -342,7 +342,7 @@ void ShearInversions::flexion2kappa(double pixel_size, double* pt_F1, double* pt
 
 }
 
-void ShearInversions::gamma_flexion2kappa(double pixel_size, to_array< double, true >& gamma1, to_array< double, true >& gamma2, to_array< double, true >& F1, to_array< double, true >& F2, to_array< double, true >& kappa)
+void ShearInversions::gamma_flexion2kappa(double pixel_size, convert_to_array< double, true >& gamma1, convert_to_array< double, true >& gamma2, convert_to_array< double, true >& F1, convert_to_array< double, true >& F2, convert_to_array< double, true >& kappa)
 {
     double *pt_gamma1 = gamma1.buffer();
     double *pt_gamma2 = gamma2.buffer();

--- a/src/mr/libmr2d/Wavelet_wmir.h
+++ b/src/mr/libmr2d/Wavelet_wmir.h
@@ -64,17 +64,17 @@ class OrthogonalWaveletTransform
 		// (I)DWT 1D along a certain axis
 		// only used by (I)DWT3D
 		// axis = 0, 1, 2 : X, Y, Z
-		static void transformXYZ (to_array<DATATYPE, true> &data, dblarray &dfilterh, dblarray &dfilterg, to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int axis, type_border BORDERTYPE);
-		static void reconstructionXYZ (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, dblarray &rfilterh, dblarray &rfilterg, to_array<DATATYPE, true> &data, int axis);
+		static void transformXYZ (convert_to_array<DATATYPE, true> &data, dblarray &dfilterh, dblarray &dfilterg, convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int axis, type_border BORDERTYPE);
+		static void reconstructionXYZ (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, dblarray &rfilterh, dblarray &rfilterg, convert_to_array<DATATYPE, true> &data, int axis);
 		
 	public:
 		// orthogonal wavelet types
 		static const int HAAR=0, DAUB4=4, SYML4=16;
 		
 		// resize the data to the same size of the reference
-		static void resizeData (to_array<DATATYPE, true> &data, to_array<DATATYPE, true> &ref, type_border BORDERTYPE=I_ZERO);
+		static void resizeData (convert_to_array<DATATYPE, true> &data, convert_to_array<DATATYPE, true> &ref, type_border BORDERTYPE=I_ZERO);
 		// resize the data to [nx], [nx, ny] or [nx, ny, nz] according to the dimension of the data
-		static void resizeData (to_array<DATATYPE, true> &data, int nx, int ny, int nz, type_border BORDERTYPE=I_ZERO);
+		static void resizeData (convert_to_array<DATATYPE, true> &data, int nx, int ny, int nz, type_border BORDERTYPE=I_ZERO);
 		
 		// get the decomposition filters, i.e. \bar{h}, \bar{g}
 		// where h is considered to start from the origin
@@ -83,88 +83,88 @@ class OrthogonalWaveletTransform
 		static void getWaveletReconsFilter (int filterName, dblarray &rfilterh, dblarray &rfilterg);
 		
 		// DWT 1D
-		static void dwt1D (to_array<DATATYPE, true> &data, \
+		static void dwt1D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE=I_MIRROR);
-		static void dwt1D (to_array<DATATYPE, true> &data, \
+		static void dwt1D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE=I_MIRROR);
 		
 		// IDWT 1D 
-		static void idwt1D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+		static void idwt1D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data);
-		static void idwt1D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &data);
+		static void idwt1D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			int filterName, \
-			to_array<DATATYPE, true> &data);			
+			convert_to_array<DATATYPE, true> &data);			
 
 		// DWT 2D
-		static void dwt2D (to_array<DATATYPE, true> &data, \
+		static void dwt2D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE=I_MIRROR);
-		static void dwt2D (to_array<DATATYPE, true> &data, \
+		static void dwt2D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE=I_MIRROR);
 					
 		// IDWT 2D 
-		static void idwt2D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+		static void idwt2D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data);
-		static void idwt2D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &data);
+		static void idwt2D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			int filterName, \
-			to_array<DATATYPE, true> &data);
+			convert_to_array<DATATYPE, true> &data);
 
 		// DWT 3D
-		static void dwt3D (to_array<DATATYPE, true> &data, \
+		static void dwt3D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			type_border BORDERTYPE=I_MIRROR);
-		static void dwt3D (to_array<DATATYPE, true> &data, \
+		static void dwt3D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			type_border BORDERTYPE=I_MIRROR);
 					
 		// IDWT 3D 
 		static void idwt3D ( \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data);
+			convert_to_array<DATATYPE, true> &data);
 		static void idwt3D ( \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			int filterName, \
-			to_array<DATATYPE, true> &data);
+			convert_to_array<DATATYPE, true> &data);
 };
 
 template <class DATATYPE>
@@ -177,19 +177,19 @@ template <class DATATYPE>
 const int OrthogonalWaveletTransform<DATATYPE>::SYML4;
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::resizeData(to_array<DATATYPE, true> &data, to_array<DATATYPE, true> &ref, type_border BORDERTYPE)
+void OrthogonalWaveletTransform<DATATYPE>::resizeData(convert_to_array<DATATYPE, true> &data, convert_to_array<DATATYPE, true> &ref, type_border BORDERTYPE)
 {
 	resizeData(data, ref.nx(), ref.ny(), ref.nz(), BORDERTYPE);
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::resizeData(to_array<DATATYPE, true> &data, int nx, int ny, int nz, type_border BORDERTYPE)
+void OrthogonalWaveletTransform<DATATYPE>::resizeData(convert_to_array<DATATYPE, true> &data, int nx, int ny, int nz, type_border BORDERTYPE)
 {
 	int dnx = data.nx(), dny = data.ny(), dnz = data.nz();
 	if ((nx == dnx) && (ny == dny) && (nz == dnz)) return;
 	int dim = data.naxis();
 
-	to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(dnx, dny, dnz);
+	convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(dnx, dny, dnz);
 	*temp = data;
 	if (dim == 1)
 	{
@@ -272,9 +272,9 @@ void OrthogonalWaveletTransform<DATATYPE>::getWaveletReconsFilter (int filterNam
 }
 
 template <class DATATYPE>
-void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true> &data, dblarray &dfilterh, dblarray &dfilterg, to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int axis, type_border BORDERTYPE)
+void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (convert_to_array<DATATYPE, true> &data, dblarray &dfilterh, dblarray &dfilterg, convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int axis, type_border BORDERTYPE)
 {
-	to_array<DATATYPE, true> *line = NULL, *linea = NULL, *lined = NULL;
+	convert_to_array<DATATYPE, true> *line = NULL, *linea = NULL, *lined = NULL;
 	int lenx, leny, lenz, dlenx, dleny, dlenz;
 	
 	if (axis == 0)
@@ -283,9 +283,9 @@ void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true
 		dlenx = getDecompResultLength(lenx, dfilterh.n_elem());
 		ca.resize(dlenx, leny, lenz);
 		cd.resize(dlenx, leny, lenz);
-		line = new to_array<DATATYPE, true>(lenx);
-		linea = new to_array<DATATYPE, true>(dlenx);
-		lined = new to_array<DATATYPE, true>(dlenx);
+		line = new convert_to_array<DATATYPE, true>(lenx);
+		linea = new convert_to_array<DATATYPE, true>(dlenx);
+		lined = new convert_to_array<DATATYPE, true>(dlenx);
 		
 		for (int z=0; z<lenz; z++)
 		for (int y=0; y<leny; y++)
@@ -306,9 +306,9 @@ void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true
 		dleny = getDecompResultLength(leny, dfilterh.n_elem());
 		ca.resize(lenx, dleny, lenz);
 		cd.resize(lenx, dleny, lenz);
-		line = new to_array<DATATYPE, true>(leny);
-		linea = new to_array<DATATYPE, true>(dleny);
-		lined = new to_array<DATATYPE, true>(dleny);
+		line = new convert_to_array<DATATYPE, true>(leny);
+		linea = new convert_to_array<DATATYPE, true>(dleny);
+		lined = new convert_to_array<DATATYPE, true>(dleny);
 
 		for (int z=0; z<lenz; z++)
 		for (int x=0; x<lenx; x++)
@@ -329,9 +329,9 @@ void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true
 		dlenz = getDecompResultLength(lenz, dfilterh.n_elem());	
 		ca.resize(lenx, leny, dlenz);
 		cd.resize(lenx, leny, dlenz);
-		line = new to_array<DATATYPE, true>(lenz);
-		linea = new to_array<DATATYPE, true>(dlenz);
-		lined = new to_array<DATATYPE, true>(dlenz);
+		line = new convert_to_array<DATATYPE, true>(lenz);
+		linea = new convert_to_array<DATATYPE, true>(dlenz);
+		lined = new convert_to_array<DATATYPE, true>(dlenz);
 
 		for (int y=0; y<leny; y++)
 		for (int x=0; x<lenx; x++)
@@ -354,18 +354,18 @@ void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true
 }
 
 template <class DATATYPE>
-void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, dblarray &rfilterh, dblarray &rfilterg, to_array<DATATYPE, true> &data, int axis)
+void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, dblarray &rfilterh, dblarray &rfilterg, convert_to_array<DATATYPE, true> &data, int axis)
 {
-	to_array<DATATYPE, true> *line = NULL, *linea = NULL, *lined = NULL;
+	convert_to_array<DATATYPE, true> *line = NULL, *linea = NULL, *lined = NULL;
 	int lenx, leny, lenz, rlenx, rleny, rlenz;
 	
 	if (axis == 0)
 	{
 		lenx = ca.nx(); leny = ca.ny(); lenz = ca.nz();
 		rlenx = getReconsResultLength(lenx, rfilterh.n_elem());
-		line = new to_array<DATATYPE, true>(rlenx);
-		linea = new to_array<DATATYPE, true>(lenx);
-		lined = new to_array<DATATYPE, true>(lenx);
+		line = new convert_to_array<DATATYPE, true>(rlenx);
+		linea = new convert_to_array<DATATYPE, true>(lenx);
+		lined = new convert_to_array<DATATYPE, true>(lenx);
 		data.resize(rlenx, leny, lenz);
 		
 		for (int z=0; z<lenz; z++)
@@ -385,9 +385,9 @@ void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (to_array<DATATYPE,
 	{
 		lenx = ca.nx(); leny = ca.ny(); lenz = ca.nz();
 		rleny = getReconsResultLength(leny, rfilterh.n_elem());
-		line = new to_array<DATATYPE, true>(rleny);
-		linea = new to_array<DATATYPE, true>(leny);
-		lined = new to_array<DATATYPE, true>(leny);
+		line = new convert_to_array<DATATYPE, true>(rleny);
+		linea = new convert_to_array<DATATYPE, true>(leny);
+		lined = new convert_to_array<DATATYPE, true>(leny);
 		data.resize(lenx, rleny, lenz);
 		
 		for (int z=0; z<lenz; z++)
@@ -407,9 +407,9 @@ void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (to_array<DATATYPE,
 	{
 		lenx = ca.nx(); leny = ca.ny(); lenz = ca.nz();
 		rlenz = getReconsResultLength(lenz, rfilterh.n_elem());
-		line = new to_array<DATATYPE, true>(rlenz);
-		linea = new to_array<DATATYPE, true>(lenz);
-		lined = new to_array<DATATYPE, true>(lenz);
+		line = new convert_to_array<DATATYPE, true>(rlenz);
+		linea = new convert_to_array<DATATYPE, true>(lenz);
+		lined = new convert_to_array<DATATYPE, true>(lenz);
 		data.resize(lenx, leny, rlenz);
 		
 		for (int y=0; y<leny; y++)
@@ -433,9 +433,9 @@ void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (to_array<DATATYPE,
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::dwt1D (to_array<DATATYPE, true> &data, \
+void OrthogonalWaveletTransform<DATATYPE>::dwt1D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE)
 {
 	int datalen = data.nx();
@@ -465,9 +465,9 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt1D (to_array<DATATYPE, true> &data
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::dwt1D (to_array<DATATYPE, true> &data, \
+void OrthogonalWaveletTransform<DATATYPE>::dwt1D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE)
 {
 	dblarray filterh, filterg;
@@ -476,9 +476,9 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt1D (to_array<DATATYPE, true> &data
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::idwt1D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+void OrthogonalWaveletTransform<DATATYPE>::idwt1D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	int calen = ca.nx(), cdlen = cd.nx();
 	if (calen != cdlen)
@@ -511,9 +511,9 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt1D (to_array<DATATYPE, true> &ca,
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::idwt1D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+void OrthogonalWaveletTransform<DATATYPE>::idwt1D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			int filterName, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	dblarray filterh, filterg;
 	getWaveletReconsFilter(filterName, filterh, filterg);
@@ -521,9 +521,9 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt1D (to_array<DATATYPE, true> &ca,
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data, \
+void OrthogonalWaveletTransform<DATATYPE>::dwt2D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE)
 {
 	int datalenx = data.nx(), dataleny = data.ny();
@@ -535,11 +535,11 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data
 	ca.resize(reslenx, resleny); 	ch.resize(reslenx, resleny);
 	cv.resize(reslenx, resleny); 	cd.resize(reslenx, resleny);
 
-	to_array<DATATYPE, true> *temph = new to_array<DATATYPE, true>(reslenx, dataleny);
-	to_array<DATATYPE, true> *tempg = new to_array<DATATYPE, true>(reslenx, dataleny);
-	to_array<DATATYPE, true> *line = new to_array<DATATYPE, true>(datalenx);
-	to_array<DATATYPE, true> *atempline = new to_array<DATATYPE, true>(reslenx);
-	to_array<DATATYPE, true> *dtempline = new to_array<DATATYPE, true>(reslenx);
+	convert_to_array<DATATYPE, true> *temph = new convert_to_array<DATATYPE, true>(reslenx, dataleny);
+	convert_to_array<DATATYPE, true> *tempg = new convert_to_array<DATATYPE, true>(reslenx, dataleny);
+	convert_to_array<DATATYPE, true> *line = new convert_to_array<DATATYPE, true>(datalenx);
+	convert_to_array<DATATYPE, true> *atempline = new convert_to_array<DATATYPE, true>(reslenx);
+	convert_to_array<DATATYPE, true> *dtempline = new convert_to_array<DATATYPE, true>(reslenx);
 	for (int y=0; y<dataleny; y++)
 	{
 		for (int x=0; x<datalenx; x++) (*line)(x) = data(x,y);
@@ -554,10 +554,10 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data
 	if (atempline != NULL) { delete atempline; atempline = NULL; }
 	if (dtempline != NULL) { delete dtempline; dtempline = NULL; }
 	
-	to_array<DATATYPE, true> *col1 = new to_array<DATATYPE, true>(dataleny);
-	to_array<DATATYPE, true> *col2 = new to_array<DATATYPE, true>(dataleny);
-	to_array<DATATYPE, true> *atempcol = new to_array<DATATYPE, true>(resleny);
-	to_array<DATATYPE, true> *dtempcol = new to_array<DATATYPE, true>(resleny);
+	convert_to_array<DATATYPE, true> *col1 = new convert_to_array<DATATYPE, true>(dataleny);
+	convert_to_array<DATATYPE, true> *col2 = new convert_to_array<DATATYPE, true>(dataleny);
+	convert_to_array<DATATYPE, true> *atempcol = new convert_to_array<DATATYPE, true>(resleny);
+	convert_to_array<DATATYPE, true> *dtempcol = new convert_to_array<DATATYPE, true>(resleny);
 	for (int x=0; x<reslenx; x++)
 	{
 		for (int y=0; y<dataleny; y++)
@@ -587,9 +587,9 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data, \
+void OrthogonalWaveletTransform<DATATYPE>::dwt2D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE)
 {
 	dblarray filterh, filterg;
@@ -598,9 +598,9 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+void OrthogonalWaveletTransform<DATATYPE>::idwt2D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	int calenx = ca.nx(), caleny = ca.ny();
 	int chlenx = ch.nx(), chleny = ch.ny();
@@ -617,14 +617,14 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca,
 	int resleny = getReconsResultLength(caleny, hlen);
 	data.resize(reslenx, resleny);
 
-	to_array<DATATYPE, true> *temph = new to_array<DATATYPE, true>(calenx, resleny);
-	to_array<DATATYPE, true> *tempg = new to_array<DATATYPE, true>(calenx, resleny);
-	to_array<DATATYPE, true> *cola = new to_array<DATATYPE, true>(caleny);
-	to_array<DATATYPE, true> *colh = new to_array<DATATYPE, true>(chleny);
-	to_array<DATATYPE, true> *colv = new to_array<DATATYPE, true>(cvleny);
-	to_array<DATATYPE, true> *cold = new to_array<DATATYPE, true>(cdleny);
-	to_array<DATATYPE, true> *coltemph = new to_array<DATATYPE, true>(resleny);	
-	to_array<DATATYPE, true> *coltempg = new to_array<DATATYPE, true>(resleny);	
+	convert_to_array<DATATYPE, true> *temph = new convert_to_array<DATATYPE, true>(calenx, resleny);
+	convert_to_array<DATATYPE, true> *tempg = new convert_to_array<DATATYPE, true>(calenx, resleny);
+	convert_to_array<DATATYPE, true> *cola = new convert_to_array<DATATYPE, true>(caleny);
+	convert_to_array<DATATYPE, true> *colh = new convert_to_array<DATATYPE, true>(chleny);
+	convert_to_array<DATATYPE, true> *colv = new convert_to_array<DATATYPE, true>(cvleny);
+	convert_to_array<DATATYPE, true> *cold = new convert_to_array<DATATYPE, true>(cdleny);
+	convert_to_array<DATATYPE, true> *coltemph = new convert_to_array<DATATYPE, true>(resleny);	
+	convert_to_array<DATATYPE, true> *coltempg = new convert_to_array<DATATYPE, true>(resleny);	
 	for (int x=0; x<calenx; x++)
 	{
 		for (int y=0; y<caleny; y++)
@@ -649,9 +649,9 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca,
 	if (coltemph != NULL) { delete coltemph; coltemph = NULL; }
 	if (coltempg != NULL) { delete coltempg; coltempg = NULL; }
 	
-	to_array<DATATYPE, true> *lineh = new to_array<DATATYPE, true>(calenx);	
-	to_array<DATATYPE, true> *lineg = new to_array<DATATYPE, true>(calenx);	
-	to_array<DATATYPE, true> *line = new to_array<DATATYPE, true>(reslenx);	
+	convert_to_array<DATATYPE, true> *lineh = new convert_to_array<DATATYPE, true>(calenx);	
+	convert_to_array<DATATYPE, true> *lineg = new convert_to_array<DATATYPE, true>(calenx);	
+	convert_to_array<DATATYPE, true> *line = new convert_to_array<DATATYPE, true>(reslenx);	
 	for (int y=0; y<resleny; y++)
 	{
 		for (int x=0; x<calenx; x++)
@@ -671,9 +671,9 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca,
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+void OrthogonalWaveletTransform<DATATYPE>::idwt2D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			int filterName, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	dblarray filterh, filterg;
 	getWaveletReconsFilter(filterName, filterh, filterg);
@@ -682,16 +682,16 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca,
 
 template <class DATATYPE>
 void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
-			to_array<DATATYPE, true> &data, \
+			convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			type_border BORDERTYPE)
 {
 	int hlen = dfilterh.n_elem(), glen = dfilterg.n_elem();
@@ -707,18 +707,18 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
 	cggh.resize(reslenx, resleny, reslenz); cggg.resize(reslenx, resleny, reslenz);
 
 	// X
-	to_array<DATATYPE, true> *temph = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temph = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempg = new convert_to_array<DATATYPE, true>;
 	transformXYZ(data, dfilterh, dfilterg, *temph, *tempg, 0, BORDERTYPE);
 	
 	// Y
-	to_array<DATATYPE, true> *temphh = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *temphg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temphh = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temphg = new convert_to_array<DATATYPE, true>;
 	transformXYZ(*temph, dfilterh, dfilterg, *temphh, *temphg, 1, BORDERTYPE);
 	if (temph != NULL) { delete temph; temph = NULL; }
 	
-	to_array<DATATYPE, true> *tempgh = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempgg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempgh = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempgg = new convert_to_array<DATATYPE, true>;
 	transformXYZ(*tempg, dfilterh, dfilterg, *tempgh, *tempgg, 1, BORDERTYPE);
 	if (tempg != NULL) { delete tempg; tempg = NULL; }
 	
@@ -736,16 +736,16 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
 
 template <class DATATYPE>
 void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
-			to_array<DATATYPE, true> &data, \
+			convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			type_border BORDERTYPE)
 {
 	dblarray filterh, filterg;
@@ -755,16 +755,16 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
 
 template <class DATATYPE>
 void OrthogonalWaveletTransform<DATATYPE>::idwt3D ( \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	int hlen = rfilterh.n_elem(), glen = rfilterg.n_elem();
 	if (hlen != glen)
@@ -791,18 +791,18 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt3D ( \
 	data.resize(reslenx, resleny, reslenz);
 	
 	// Z
-	to_array<DATATYPE, true> *temphh = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *temphg = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempgh = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempgg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temphh = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temphg = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempgh = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempgg = new convert_to_array<DATATYPE, true>;
 	reconstructionXYZ(ca, chhg, rfilterh, rfilterg, *temphh, 2);
 	reconstructionXYZ(chgh, chgg, rfilterh, rfilterg, *temphg, 2);
 	reconstructionXYZ(cghh, cghg, rfilterh, rfilterg, *tempgh, 2);
 	reconstructionXYZ(cggh, cggg, rfilterh, rfilterg, *tempgg, 2);
 	
 	// Y
-	to_array<DATATYPE, true> *temph = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temph = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempg = new convert_to_array<DATATYPE, true>;
 	reconstructionXYZ(*temphh, *temphg, rfilterh, rfilterg, *temph, 1);
 	if (temphh != NULL) { delete temphh; temphh = NULL; }
 	if (temphg != NULL) { delete temphg; temphg = NULL; }
@@ -819,16 +819,16 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt3D ( \
 
 template <class DATATYPE>
 void OrthogonalWaveletTransform<DATATYPE>::idwt3D ( \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			int filterName, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	dblarray filterh, filterg;
 	getWaveletReconsFilter(filterName, filterh, filterg);
@@ -894,7 +894,7 @@ class WaveletShrinkage
 	public:
 		// gaussian noise standard deviation MAD estimation 
 		// sigma = median (abs(waveletdata)) / 0.6745 
-		double gaussianStdDevEstim (to_array<DATATYPE, true> &waveletData);
+		double gaussianStdDevEstim (convert_to_array<DATATYPE, true> &waveletData);
 
 		// Denoise gaussian noise 
 		// Hard threshold = k * sigma; sup use -sigma / sigma (>=0) to indicate the insignificant/significant coef. region 
@@ -902,8 +902,8 @@ class WaveletShrinkage
 		// alpha is the preset p-value of the significance level when DEFAULT is not set
 		// DEFAULT indicates to use the universal threshold
 		// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double gaussHardThreshold (to_array<DATATYPE, true> &waveletData, int scale[], \
-			double alpha, double sigma, to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
+		double gaussHardThreshold (convert_to_array<DATATYPE, true> &waveletData, int scale[], \
+			double alpha, double sigma, convert_to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
 
 		// Denoise gaussian noise 
 		// Soft threshold = k * sigma; sup use -sigma / sigma (>=0) to indicate the insignificant/significant coef. region 
@@ -911,15 +911,15 @@ class WaveletShrinkage
 		// alpha is the preset p-value of the significance level when DEFAULT is not set
 		// DEFAULT indicates to use the universal threshold
 		// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double gaussSoftThreshold (to_array<DATATYPE, true> &waveletData, int scale[], \
-			double alpha, double sigma, to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
+		double gaussSoftThreshold (convert_to_array<DATATYPE, true> &waveletData, int scale[], \
+			double alpha, double sigma, convert_to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
 
 		// Denoise gaussian noise 
 		// FDR threshold; sup use -sigma / sigma (>=0) to indicate the insignificant/significant coef. region
 		// alpha is the preset FDR
       	// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double gaussFDRThreshold (to_array<DATATYPE, true> &waveletData, \
-			double sigma, double alpha, bool indep = true, to_array<SUPTYPE, true> *sup = NULL);
+		double gaussFDRThreshold (convert_to_array<DATATYPE, true> &waveletData, \
+			double sigma, double alpha, bool indep = true, convert_to_array<SUPTYPE, true> *sup = NULL);
 
 		// Direct Haar hard threshold in using Kolaczyk's approximation for Poisson noise
 		// The transform data is assumed to use L1-normalized Haar filter,
@@ -929,7 +929,7 @@ class WaveletShrinkage
 		// alpha is the preset p-value of the significance level when DEFAULT is not set
 		// DEFAULT indicates to use the universal threshold
 		// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double haarKolaThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int scale[], double alpha, to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
+		double haarKolaThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
 
 		// Direct Haar hard threshold in using modified Kolaczyk's approximation (Fisher approx.) for Poisson noise
 		// The transform data is assumed to use L1-normalized Haar filter,
@@ -939,7 +939,7 @@ class WaveletShrinkage
 		// alpha is the preset p-value of the significance level when DEFAULT is not set
 		// DEFAULT indicates to use the universal threshold
 		// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double haarMKolaThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int scale[], double alpha, to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
+		double haarMKolaThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
 
 		// Direct Haar hard threshold based on Bijaoui-Jammal's thresholding table for Poisson noise
 		// The transform data is assumed to use L1-normalized Haar filter,
@@ -947,7 +947,7 @@ class WaveletShrinkage
 		// scale[] is the scale along each direction
 		// alpha is the preset p-value of the significance level
 		// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double haarBJThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int scale[], double alpha, to_array<SUPTYPE, true> *sup = NULL); 
+		double haarBJThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup = NULL); 
 
 		// Direct Haar hard threshold based on FDR (false discovery rate) for Poisson noise
 		// for a band
@@ -956,7 +956,7 @@ class WaveletShrinkage
 		// scale[] is the scale along each direction
 		// alpha is the preset FDR
 		// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double haarFDRThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int scale[], double alpha, bool indep = true, to_array<SUPTYPE, true> *sup = NULL);
+		double haarFDRThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, bool indep = true, convert_to_array<SUPTYPE, true> *sup = NULL);
 
 		// Direct Haar hard threshold based on FDR (false discovery rate) for Poisson noise
 		// for the bands of a scale
@@ -965,7 +965,7 @@ class WaveletShrinkage
 		// scale[] is the scale along each direction
 		// alpha is the preset FDR
 		// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double haarFDRThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> cd[], int len, int scale[], double alpha, bool indep = true, to_array<SUPTYPE, true> *sup = NULL);
+		double haarFDRThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> cd[], int len, int scale[], double alpha, bool indep = true, convert_to_array<SUPTYPE, true> *sup = NULL);
 
 		// Model (prior) based Haar coef. threshold for Poisson noise
 		// The transform data is assumed to use L1-normalized Haar filter,
@@ -978,9 +978,9 @@ class WaveletShrinkage
 		// N is the length of the original data
 		// DEFAULT indicates to use the universal threshold
 		// the thresholding p-value is returned 
-		double haarModelThreshold (to_array<DATATYPE, true> &caModel, \
-               to_array<DATATYPE, true> &cdModel, to_array<DATATYPE, true> &cd, \
-               int scale[], double alpha, to_array<SUPTYPE, true> *sup = NULL, \
+		double haarModelThreshold (convert_to_array<DATATYPE, true> &caModel, \
+               convert_to_array<DATATYPE, true> &cdModel, convert_to_array<DATATYPE, true> &cd, \
+               int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup = NULL, \
                int N = 1, bool DEFAULT = false);
                
 		// Model (prior) based Haar coef. FDR threshold for Poisson noise
@@ -992,13 +992,13 @@ class WaveletShrinkage
 		// scale[] is the scale along each direction
 		// alpha is the preset FDR
 		// the thresholding p-value is returned 
-        double haarModelFDRThreshold (to_array<DATATYPE, true> &caModel, \
-               to_array<DATATYPE, true> &cdModel, to_array<DATATYPE, true> &cd, \
-               int scale[], double alpha, bool indep = true, to_array<SUPTYPE, true> *sup = NULL);               
+        double haarModelFDRThreshold (convert_to_array<DATATYPE, true> &caModel, \
+               convert_to_array<DATATYPE, true> &cdModel, convert_to_array<DATATYPE, true> &cd, \
+               int scale[], double alpha, bool indep = true, convert_to_array<SUPTYPE, true> *sup = NULL);               
 };
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussianStdDevEstim (to_array<DATATYPE, true> &waveletData)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussianStdDevEstim (convert_to_array<DATATYPE, true> &waveletData)
 {
 	double med = Utils<DATATYPE>::absMedian(waveletData);
 	
@@ -1006,7 +1006,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussianStdDevEstim (to_array<DATATY
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussHardThreshold (to_array<DATATYPE, true> &waveletData, int scale[], double alpha, double sigma, to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussHardThreshold (convert_to_array<DATATYPE, true> &waveletData, int scale[], double alpha, double sigma, convert_to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
 {
     int dim = waveletData.naxis();
 	int nx = waveletData.nx(), ny = waveletData.ny(), nz = waveletData.nz();
@@ -1071,7 +1071,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussHardThreshold (to_array<DATATYP
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussSoftThreshold (to_array<DATATYPE, true> &waveletData, int scale[], double alpha, double sigma, to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussSoftThreshold (convert_to_array<DATATYPE, true> &waveletData, int scale[], double alpha, double sigma, convert_to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
 {
     int dim = waveletData.naxis();
 	int nx = waveletData.nx(), ny = waveletData.ny(), nz = waveletData.nz();
@@ -1149,8 +1149,8 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussSoftThreshold (to_array<DATATYP
 	return (DEFAULT ? (2.*(1-Utils<double>::cumNormal(cthresh))) : alpha);
 }
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE, true> &waveletData, \
-					  double sigma, double alpha, bool indep, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (convert_to_array<DATATYPE, true> &waveletData, \
+					  double sigma, double alpha, bool indep, convert_to_array<SUPTYPE, true> *sup)
 {
   int dim = waveletData.naxis();
   int nx = waveletData.nx(), ny = waveletData.ny(), nz = waveletData.nz();
@@ -1159,7 +1159,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE
   if (dim == 1)
     {
       if (sup != NULL) sup->resize(nx);
-      to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx);
+      convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx);
       for (int x=0; x<nx; x++)
 	  {
 	  if (sigma < 1e-20) (*pvals)(x) = 0;
@@ -1189,7 +1189,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE
   else if (dim == 2)
     {
       if (sup != NULL) sup->resize(nx, ny);
-      to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny);
+      convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny);
       for (int x=0; x<nx; x++)
       for (int y=0; y<ny; y++)
 	  {
@@ -1221,7 +1221,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE
   else if (dim == 3)
     {
       if (sup != NULL) sup->resize(nx, ny, nz);
-      to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny, nz);
+      convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny, nz);
       for (int x=0; x<nx; x++)
       for (int y=0; y<ny; y++)
       for (int z=0; z<nz; z++)
@@ -1258,7 +1258,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::haarKolaThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int scale[], double alpha, to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::haarKolaThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
 {
 	int nx, ny, nz;
 	double coeff, lambda, thresh, zalpha2;
@@ -1348,8 +1348,8 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarKolaThreshold (to_array<DATATYPE
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::haarMKolaThreshold (to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &cd, int scale[], double alpha, to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::haarMKolaThreshold (convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
 {
 	int nx, ny, nz, rn;
 	double coeff, pcoef[5], pm[4], pmi[4], lambda, thresh, zalpha2;
@@ -1473,7 +1473,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarMKolaThreshold (to_array<DATATYP
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::haarBJThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int scale[], double alpha, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::haarBJThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup)
 {
 	int nx, ny, nz;
 	double coeff, lambda, thresh, alpha2 = alpha / 2.;
@@ -1558,7 +1558,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarBJThreshold (to_array<DATATYPE, 
 }
 
 template <class DATATYPE, class SUPTYPE>
-double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int scale[], double alpha, bool indep, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, bool indep, convert_to_array<SUPTYPE, true> *sup)
 {
 	int nx, ny, nz;
 	double coeff, lambda, fdrp;
@@ -1573,7 +1573,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 	{
 		nx = cd.nx();
 		if (sup != NULL) sup->resize(nx);
-	        to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx);
+	        convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx);
 		for (int x=0; x<nx; x++)
 		{
 			lambda = MAX(0, ca(x)); lambdaj = lambdajparam * lambda;
@@ -1608,7 +1608,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 	{
 	        nx = cd.nx(); ny = cd.ny();
 		if (sup != NULL) sup->resize(nx, ny);
-	        to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny);
+	        convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny);
 		for (int x=0; x<nx; x++)
 		for (int y=0; y<ny; y++)
 		{
@@ -1646,7 +1646,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 	{
   	        nx = cd.nx(); ny = cd.ny(); nz = cd.nz();
 		if (sup != NULL) sup->resize(nx, ny, nz);
-	        to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny, nz);
+	        convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny, nz);
 		for (int x=0; x<nx; x++)
 		for (int y=0; y<ny; y++)
 		for (int z=0; z<nz; z++)
@@ -1688,7 +1688,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 }
 
 template <class DATATYPE, class SUPTYPE>
-double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> cd[], int len, int scale[], double alpha, bool indep, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> cd[], int len, int scale[], double alpha, bool indep, convert_to_array<SUPTYPE, true> *sup)
 {
 	int nx, ny, nz;
 	double coeff, lambda, fdrp;
@@ -1703,7 +1703,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 	{
 	    nx = cd[0].nx();
 	    if (sup != NULL) for (int l=0; l<len; l++) sup[l].resize(nx);
-	    to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(len, nx);
+	    convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(len, nx);
 		for (int l=0; l<len; l++)
 		for (int x=0; x<nx; x++)
 		{
@@ -1741,7 +1741,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 	{
 	    nx = cd[0].nx(); ny = cd[0].ny();
 		if (sup != NULL) for (int l=0; l<len; l++) sup[l].resize(nx, ny);
-	    to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(len, nx, ny);
+	    convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(len, nx, ny);
 		for (int l=0; l<len; l++)
 		for (int x=0; x<nx; x++)
 		for (int y=0; y<ny; y++)
@@ -1781,7 +1781,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 	{
   	    nx = cd[0].nx(); ny = cd[0].ny(); nz = cd[0].nz();
 		if (sup != NULL) for (int l=0; l<len; l++) sup[l].resize(nx, ny, nz);
-	    to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(len*nx, ny, nz);
+	    convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(len*nx, ny, nz);
 		for (int l=0; l<len; l++)
 		for (int x=0; x<nx; x++)
 		for (int y=0; y<ny; y++)
@@ -1825,9 +1825,9 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 }
 
 template <class DATATYPE, class SUPTYPE>
-double WaveletShrinkage<DATATYPE, SUPTYPE>::haarModelThreshold (to_array<DATATYPE, true> &caModel, \
-               to_array<DATATYPE, true> &cdModel, to_array<DATATYPE, true> &cd, \
-               int scale[], double alpha, to_array<SUPTYPE, true> *sup, \
+double WaveletShrinkage<DATATYPE, SUPTYPE>::haarModelThreshold (convert_to_array<DATATYPE, true> &caModel, \
+               convert_to_array<DATATYPE, true> &cdModel, convert_to_array<DATATYPE, true> &cd, \
+               int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup, \
                int N, bool DEFAULT)
 {
 	int nx, ny, nz;
@@ -1915,9 +1915,9 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarModelThreshold (to_array<DATATYP
 
 template <class DATATYPE, class SUPTYPE>
 double WaveletShrinkage<DATATYPE, SUPTYPE>::haarModelFDRThreshold \
-       (to_array<DATATYPE, true> &caModel, \
-        to_array<DATATYPE, true> &cdModel, to_array<DATATYPE, true> &cd, \
-        int scale[], double alpha, bool indep, to_array<SUPTYPE, true> *sup)
+       (convert_to_array<DATATYPE, true> &caModel, \
+        convert_to_array<DATATYPE, true> &cdModel, convert_to_array<DATATYPE, true> &cd, \
+        int scale[], double alpha, bool indep, convert_to_array<SUPTYPE, true> *sup)
 {
 	int nx, ny, nz;
 	double coefobs, lambda1, lambda2, p, fdrp;
@@ -1931,7 +1931,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarModelFDRThreshold \
 	{
 		nx = cd.nx();
 		if (sup != NULL) sup->resize(nx);
-	    to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx);
+	    convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx);
 		for (int x=0; x<nx; x++)
 		{
             coefobs = cd(x);
@@ -1966,7 +1966,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarModelFDRThreshold \
 	{
 	    nx = cd.nx(); ny = cd.ny();
 		if (sup != NULL) sup->resize(nx, ny);
-	    to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny);
+	    convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny);
 		for (int x=0; x<nx; x++)
 		for (int y=0; y<ny; y++)
 		{
@@ -2003,7 +2003,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarModelFDRThreshold \
 	{
   	    nx = cd.nx(); ny = cd.ny(); nz = cd.nz();
 		if (sup != NULL) sup->resize(nx, ny, nz);
-	    to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny, nz);
+	    convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny, nz);
 		for (int x=0; x<nx; x++)
 		for (int y=0; y<ny; y++)
 		for (int z=0; z<nz; z++)

--- a/src/mrs/libmrs/mrs_planck_lGMCA.h
+++ b/src/mrs/libmrs/mrs_planck_lGMCA.h
@@ -106,9 +106,9 @@ public:
 
 	C_UWT2D_ATROUS WT_Trans; //will contain the wavelet transform routines for the Nchannels 
 	
- 	to_array<unsigned long,true> FaceIndices;//Index of each pixel in a face in Healpix Ring format
- 	to_array<unsigned long,true> Nest2Ring_indices;//Index of each pixel in a face in Healpix Ring format
- 	to_array<unsigned long,true> Ring2Nest_indices;//Index of each pixel in a face in Healpix Ring format
+ 	convert_to_array<unsigned long,true> FaceIndices;//Index of each pixel in a face in Healpix Ring format
+ 	convert_to_array<unsigned long,true> Nest2Ring_indices;//Index of each pixel in a face in Healpix Ring format
+ 	convert_to_array<unsigned long,true> Ring2Nest_indices;//Index of each pixel in a face in Healpix Ring format
  	
 	bool Verbose;
 	bool Debug;

--- a/src/msvst/libmsvst/Fisz.h
+++ b/src/msvst/libmsvst/Fisz.h
@@ -22,27 +22,27 @@ class FiszTransform
 		// dimension of the nearest power of two,
 		// if the data size is not of power two;
 		// ext is an array of 6 elements (extension information of 6 directions)
-		void dataExtension (to_array<DATATYPE, true> &data, int ext[], type_border BORDERTYPE=I_MIRROR);
+		void dataExtension (convert_to_array<DATATYPE, true> &data, int ext[], type_border BORDERTYPE=I_MIRROR);
 		// extract the original data in using the extension information
-		void dataExtraction (to_array<DATATYPE, true> &data, int ext[]);
+		void dataExtraction (convert_to_array<DATATYPE, true> &data, int ext[]);
 		
 		// Fisz transform 1D / 2D / 3D
 		// the data size MUST be power of two, 
 		// otherwise, a DataSizeException will be thrown out
-		void fisz1D (to_array<DATATYPE, true> &data);
-		void fisz2D (to_array<DATATYPE, true> &data);
-		void fisz3D (to_array<DATATYPE, true> &data);
+		void fisz1D (convert_to_array<DATATYPE, true> &data);
+		void fisz2D (convert_to_array<DATATYPE, true> &data);
+		void fisz3D (convert_to_array<DATATYPE, true> &data);
 
 		// Inverse Fisz transform 1D / 2D / 3D
 		// data size MUST be power of two.
 		// otherwise, a DataSizeException will be thrown out
-		void ifisz1D (to_array<DATATYPE, true> &data);
-		void ifisz2D (to_array<DATATYPE, true> &data);
-		void ifisz3D (to_array<DATATYPE, true> &data);
+		void ifisz1D (convert_to_array<DATATYPE, true> &data);
+		void ifisz2D (convert_to_array<DATATYPE, true> &data);
+		void ifisz3D (convert_to_array<DATATYPE, true> &data);
 };
 
 template <class DATATYPE>
-void FiszTransform<DATATYPE>::dataExtension (to_array<DATATYPE, true> &data, int ext[], type_border BORDERTYPE)
+void FiszTransform<DATATYPE>::dataExtension (convert_to_array<DATATYPE, true> &data, int ext[], type_border BORDERTYPE)
 {
 	int lext = 0, rext = 0, uext = 0, dext = 0, bext = 0, fext = 0;
 	int dim = data.naxis();
@@ -54,7 +54,7 @@ void FiszTransform<DATATYPE>::dataExtension (to_array<DATATYPE, true> &data, int
 		lext = (newlen - len1) / 2; 
 		rext = (newlen - len1) - lext;
 		
-		to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen);
+		convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen);
 		for (int x=0; x<newlen; x++)
 			(*temp)(x) = data(x-lext, BORDERTYPE);
 		data = *temp;
@@ -72,7 +72,7 @@ void FiszTransform<DATATYPE>::dataExtension (to_array<DATATYPE, true> &data, int
 		lext = (newlen1 - len1) / 2; rext = (newlen1 - len1) - lext;
 		uext = (newlen2 - len2) / 2; dext = (newlen2 - len2) - uext;
 		
-		to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen1, newlen2);
+		convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen1, newlen2);
 		for (int y=0; y<newlen2; y++)
 			for (int x=0; x<newlen1; x++)
 				(*temp)(x, y) = data(x-lext, y-uext, BORDERTYPE);
@@ -92,7 +92,7 @@ void FiszTransform<DATATYPE>::dataExtension (to_array<DATATYPE, true> &data, int
 		uext = (newlen2 - len2) / 2; dext = (newlen2 - len2) - uext;
 		bext = (newlen3 - len3) / 2; fext = (newlen3 - len3) - fext;
 		
-		to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen1, newlen2, newlen3);
+		convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen1, newlen2, newlen3);
 		for (int z=0; z<newlen3; z++)
 			for (int y=0; y<newlen2; y++)
 				for (int x=0; x<newlen1; x++)
@@ -106,7 +106,7 @@ void FiszTransform<DATATYPE>::dataExtension (to_array<DATATYPE, true> &data, int
 }
 
 template<class DATATYPE>
-void FiszTransform<DATATYPE>::dataExtraction (to_array<DATATYPE, true> &data, int ext[])
+void FiszTransform<DATATYPE>::dataExtraction (convert_to_array<DATATYPE, true> &data, int ext[])
 {
 	int dim = data.naxis();
 	int lext = ext[0], rext = ext[1], uext = ext[2];
@@ -115,7 +115,7 @@ void FiszTransform<DATATYPE>::dataExtraction (to_array<DATATYPE, true> &data, in
 	if ((dim == 1) && ((lext != 0) || (rext != 0)))
 	{
 		int finallen = data.nx() - lext - rext;
-		to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen);
+		convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen);
 		for (int x=0; x<finallen; x++) (*tdata)(x) = data(lext+x);
 		data = (*tdata);
 		if (tdata != NULL) { delete tdata; tdata = NULL; }
@@ -125,7 +125,7 @@ void FiszTransform<DATATYPE>::dataExtraction (to_array<DATATYPE, true> &data, in
 	{
 		int finallen1 = data.nx() - lext - rext;
 		int finallen2 = data.ny() - uext - dext;
-		to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen1, finallen2);
+		convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen1, finallen2);
 		for (int x=0; x<finallen1; x++) 
 			for (int y=0; y<finallen2; y++)
 				(*tdata)(x, y) = data(lext+x, uext+y);
@@ -139,7 +139,7 @@ void FiszTransform<DATATYPE>::dataExtraction (to_array<DATATYPE, true> &data, in
 		int finallen1 = data.nx() - lext - rext;
 		int finallen2 = data.ny() - uext - dext;
 		int finallen3 = data.nz() - bext - fext;
-		to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen1, finallen2, finallen3);
+		convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen1, finallen2, finallen3);
 		for (int x=0; x<finallen1; x++) 
 		for (int y=0; y<finallen2; y++)
 		for (int z=0; z<finallen3; z++)	
@@ -150,14 +150,14 @@ void FiszTransform<DATATYPE>::dataExtraction (to_array<DATATYPE, true> &data, in
 }
 
 template<class DATATYPE>
-void FiszTransform<DATATYPE>::fisz1D (to_array<DATATYPE, true> &data)
+void FiszTransform<DATATYPE>::fisz1D (convert_to_array<DATATYPE, true> &data)
 {
     double ca, cd;
 	int len = data.nx();	
 	if (len <= 1) return;
 	else if (!is_power_of_2(len)) 
 		throw DataSizeException(len, "data size not of power of two");
-	to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(len);
+	convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(len);
 	
 	// decomposition by Haar transform and modification of detail coefficients
 	while (len > 1)
@@ -193,14 +193,14 @@ void FiszTransform<DATATYPE>::fisz1D (to_array<DATATYPE, true> &data)
 }
 
 template<class DATATYPE>
-void FiszTransform<DATATYPE>::ifisz1D (to_array<DATATYPE, true> &data)
+void FiszTransform<DATATYPE>::ifisz1D (convert_to_array<DATATYPE, true> &data)
 {
     double ca, cd;
 	int len = data.nx();
 	if (len <= 1) return;
 	else if (!is_power_of_2(len)) 
 		throw DataSizeException(len, "data size not of power of two");
-	to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(len);
+	convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(len);
 	
 	// decomposition by Haar transform
 	while (len > 1)
@@ -232,7 +232,7 @@ void FiszTransform<DATATYPE>::ifisz1D (to_array<DATATYPE, true> &data)
 }
 
 template<class DATATYPE>
-void FiszTransform<DATATYPE>::fisz2D (to_array<DATATYPE, true> &data)
+void FiszTransform<DATATYPE>::fisz2D (convert_to_array<DATATYPE, true> &data)
 {
 	double ca, dh, dv, dd;
 	int s, offsetx, offsety;
@@ -242,7 +242,7 @@ void FiszTransform<DATATYPE>::fisz2D (to_array<DATATYPE, true> &data)
 		throw DataSizeException(len1, "data size not of power of two");
 	else if (!is_power_of_2(len2))
 		throw DataSizeException(len2, "data size not of power of two");	
-	to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(len1, len2);
+	convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(len1, len2);
 	
 	// decomposition by Haar transform and modification of detail coefficients
 	while ((len1 > 1) && (len2 > 1))
@@ -318,7 +318,7 @@ void FiszTransform<DATATYPE>::fisz2D (to_array<DATATYPE, true> &data)
 }
 
 template<class DATATYPE>
-void FiszTransform<DATATYPE>::ifisz2D (to_array<DATATYPE, true> &data)
+void FiszTransform<DATATYPE>::ifisz2D (convert_to_array<DATATYPE, true> &data)
 {
 	double ca, dh, dv, dd;
 	int s, offsetx, offsety;
@@ -328,7 +328,7 @@ void FiszTransform<DATATYPE>::ifisz2D (to_array<DATATYPE, true> &data)
 		throw DataSizeException(len1, "data size not of power of two");
 	else if (!is_power_of_2(len2))
 		throw DataSizeException(len2, "data size not of power of two");
-	to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(len1, len2);
+	convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(len1, len2);
 	
 	// decomposition by Haar transform
 	while ((len1 > 1) && (len2 > 1))
@@ -396,7 +396,7 @@ void FiszTransform<DATATYPE>::ifisz2D (to_array<DATATYPE, true> &data)
 }
 
 template<class DATATYPE>
-void FiszTransform<DATATYPE>::fisz3D (to_array<DATATYPE, true> &data)
+void FiszTransform<DATATYPE>::fisz3D (convert_to_array<DATATYPE, true> &data)
 {
 	int len1 = data.nx(), len2 = data.ny(), len3 = data.nz();
 	int len = MIN(MIN(len1, len2), len3);
@@ -409,7 +409,7 @@ void FiszTransform<DATATYPE>::fisz3D (to_array<DATATYPE, true> &data)
 		throw DataSizeException(len3, "data size not of power of two");
 	
 	int s = iilog2(len);
-	to_array<DATATYPE, true> *coef = new to_array<DATATYPE, true>[7*s + 1];
+	convert_to_array<DATATYPE, true> *coef = new convert_to_array<DATATYPE, true>[7*s + 1];
 	
 	dblarray dfilterh(2), dfilterg(2), rfilterh(2), rfilterg(2);
 	dfilterh(0) = .5; dfilterh(1) = .5; dfilterg(0) = -.5; dfilterg(1) = .5;
@@ -449,7 +449,7 @@ void FiszTransform<DATATYPE>::fisz3D (to_array<DATATYPE, true> &data)
 }
 
 template<class DATATYPE>
-void FiszTransform<DATATYPE>::ifisz3D (to_array<DATATYPE, true> &data)
+void FiszTransform<DATATYPE>::ifisz3D (convert_to_array<DATATYPE, true> &data)
 {
 	int len1 = data.nx(), len2 = data.ny(), len3 = data.nz();
 	int len = MIN(MIN(len1, len2), len3);
@@ -462,7 +462,7 @@ void FiszTransform<DATATYPE>::ifisz3D (to_array<DATATYPE, true> &data)
 		throw DataSizeException(len3, "data size not of power of two");
 
 	int s = iilog2(len);
-	to_array<DATATYPE, true> *coef = new to_array<DATATYPE, true>[7*s + 1];
+	convert_to_array<DATATYPE, true> *coef = new convert_to_array<DATATYPE, true>[7*s + 1];
 	
 	dblarray dfilterh(2), dfilterg(2), rfilterh(2), rfilterg(2);
 	dfilterh(0) = .5; dfilterh(1) = .5; dfilterg(0) = -.5; dfilterg(1) = .5;

--- a/src/msvst/libmsvst/ImLib_msvst.h
+++ b/src/msvst/libmsvst/ImLib_msvst.h
@@ -97,27 +97,27 @@ class Utils
 
  public:
   // median value of the absolute value of a given data set
-  static DATATYPE absMedian (to_array<DATATYPE, true> &data);
+  static DATATYPE absMedian (convert_to_array<DATATYPE, true> &data);
   // critical threshold for standard normal distribution, tailProba <= 0.5
   static double criticalThreshGauss (double tailProba);
   // cumulative of the normal distribution
   static double cumNormal (double x);
   // Anscombe transform of a data set
-  static void anscombeTransform (to_array<DATATYPE, true> &data);
+  static void anscombeTransform (convert_to_array<DATATYPE, true> &data);
   // Inverse Anscombe transform of a data set
   // bias correction is recommended while reconstruct the data after estimation
-  static void invAnscombeTransform (to_array<DATATYPE, true> &data, bool cbias);
+  static void invAnscombeTransform (convert_to_array<DATATYPE, true> &data, bool cbias);
 
   // generate Donoho's clipped block 1D signal
-  static void blockSignal (int len, double scaling, to_array<DATATYPE, true> &signal1D);
+  static void blockSignal (int len, double scaling, convert_to_array<DATATYPE, true> &signal1D);
   // generate a 1D signal with a Gaussian form
-  static void regularSignal (int cx, double sigma, double peakIntense, double backIntense, to_array<DATATYPE, true> &signal1D);
+  static void regularSignal (int cx, double sigma, double peakIntense, double backIntense, convert_to_array<DATATYPE, true> &signal1D);
   // generate a 3D signal with a regional evolutionary Gaussian form
   static void regularSignal (int cx, int cy, double sigma0, double sigma1, double k, \
-			     double peakIntense, double backIntense, to_array<DATATYPE, true> &signal3D, double flow[]);
+			     double peakIntense, double backIntense, convert_to_array<DATATYPE, true> &signal3D, double flow[]);
 
   // calculate the source flow of a Gaussian form signal
-  static void gaussianSourceFlow (to_array<DATATYPE, true> &signal3D, double cx, double cy, \
+  static void gaussianSourceFlow (convert_to_array<DATATYPE, true> &signal3D, double cx, double cy, \
 				  double sigma0, double sigma1, double k, double backIntense, double flow[]);
 
   // mean of a vector
@@ -125,9 +125,9 @@ class Utils
   // standard deviation of a vector
   static double std (DATATYPE vec[], int len);
   // Normalized Integrated Square Error where the noise is Poissonian
-  static double NISE (to_array<DATATYPE, true> &orig, to_array<DATATYPE, true> &estim);
+  static double NISE (convert_to_array<DATATYPE, true> &orig, convert_to_array<DATATYPE, true> &estim);
   // Integrated Square Error where the noise has a spatially stable variance
-  static double ISE (to_array<DATATYPE, true> &orig, to_array<DATATYPE, true> &estim);
+  static double ISE (convert_to_array<DATATYPE, true> &orig, convert_to_array<DATATYPE, true> &estim);
 
   // return the combinatorial number C(n, k)
   static double Cnk (int n, int k);
@@ -141,7 +141,7 @@ class Utils
   // ndet  record for each pixel, the number of detection among NExp experiences
   // ndlen is the length of the array ndet
   // NITER is max. number of iteration
-  static void EMMixBinomialParam (double &alpha, double &pa, double &pi, int NExp, to_array<DATATYPE, true> ndet[], int ndlen, int NITER);
+  static void EMMixBinomialParam (double &alpha, double &pa, double &pi, int NExp, convert_to_array<DATATYPE, true> ndet[], int ndlen, int NITER);
   // ROC area where [alpha0, alpha1] is the valid H0 portion interval
   // static double rocArea (int len, double alpha[], double pa[], double pi[], double alpha0, double alpha1);
   // ROC area
@@ -187,7 +187,7 @@ class Utils
 };
 
 template <class DATATYPE> 
-DATATYPE Utils<DATATYPE>::absMedian (to_array<DATATYPE, true> &data)
+DATATYPE Utils<DATATYPE>::absMedian (convert_to_array<DATATYPE, true> &data)
 {
 	DATATYPE medv;
 	int less, greater, equal;
@@ -257,7 +257,7 @@ double Utils<DATATYPE>::cumNormal (double x)
 }
 
 template <class DATATYPE> 
-void Utils<DATATYPE>::anscombeTransform (to_array<DATATYPE, true> &data)
+void Utils<DATATYPE>::anscombeTransform (convert_to_array<DATATYPE, true> &data)
 {
   int nlen = data.n_elem();
   for (int i=0; i<nlen; i++)
@@ -265,7 +265,7 @@ void Utils<DATATYPE>::anscombeTransform (to_array<DATATYPE, true> &data)
 }
 
 template <class DATATYPE> 
-void Utils<DATATYPE>::invAnscombeTransform (to_array<DATATYPE, true> &data, bool cbias)
+void Utils<DATATYPE>::invAnscombeTransform (convert_to_array<DATATYPE, true> &data, bool cbias)
 {
   double cb = cbias ? 1. : 0.;  
   int nlen = data.n_elem();
@@ -274,7 +274,7 @@ void Utils<DATATYPE>::invAnscombeTransform (to_array<DATATYPE, true> &data, bool
 }
 
 template <class DATATYPE> 
-void Utils<DATATYPE>::blockSignal (int len, double scaling, to_array<DATATYPE, true> &signal1D)
+void Utils<DATATYPE>::blockSignal (int len, double scaling, convert_to_array<DATATYPE, true> &signal1D)
 {
   signal1D.resize(len);
 
@@ -292,7 +292,7 @@ void Utils<DATATYPE>::blockSignal (int len, double scaling, to_array<DATATYPE, t
 }
 
 template <class DATATYPE>
-void Utils<DATATYPE>::regularSignal (int cx, double sigma, double peakIntense, double backIntense, to_array<DATATYPE, true> &signal1D)
+void Utils<DATATYPE>::regularSignal (int cx, double sigma, double peakIntense, double backIntense, convert_to_array<DATATYPE, true> &signal1D)
 {
   int nx = signal1D.nx();
   double sig = 2. * sigma * sigma;
@@ -303,7 +303,7 @@ void Utils<DATATYPE>::regularSignal (int cx, double sigma, double peakIntense, d
 
 template <class DATATYPE> 
 void Utils<DATATYPE>::regularSignal (int cx, int cy, double sigma0, double sigma1, double k, \
-				     double peakIntense, double backIntense, to_array<DATATYPE, true> &signal3D, double flow[])
+				     double peakIntense, double backIntense, convert_to_array<DATATYPE, true> &signal3D, double flow[])
 {
   int nx = signal3D.nx(), ny = signal3D.ny(), nz = signal3D.nz();
   double dsig = (sigma1 - sigma0) / (nz - 1), sig = sigma0;
@@ -333,7 +333,7 @@ void Utils<DATATYPE>::regularSignal (int cx, int cy, double sigma0, double sigma
 }
 
 template <class DATATYPE>
-void Utils<DATATYPE>::gaussianSourceFlow (to_array<DATATYPE, true> &signal3D, double cx, double cy, \
+void Utils<DATATYPE>::gaussianSourceFlow (convert_to_array<DATATYPE, true> &signal3D, double cx, double cy, \
 					  double sigma0, double sigma1, double k, double backIntense, double flow[])
 {
   int nx = signal3D.nx(), ny = signal3D.ny(), nz = signal3D.nz();
@@ -376,7 +376,7 @@ double Utils<DATATYPE>::std (DATATYPE vec[], int len)
 }
 
 template <class DATATYPE> 
-double Utils<DATATYPE>::NISE (to_array<DATATYPE, true> &orig, to_array<DATATYPE, true> &estim)
+double Utils<DATATYPE>::NISE (convert_to_array<DATATYPE, true> &orig, convert_to_array<DATATYPE, true> &estim)
 {
   int dlen = orig.n_elem();
   double sum = 0., lambda, temp;
@@ -392,7 +392,7 @@ double Utils<DATATYPE>::NISE (to_array<DATATYPE, true> &orig, to_array<DATATYPE,
 }
 
 template <class DATATYPE> 
-double Utils<DATATYPE>::ISE (to_array<DATATYPE, true> &orig, to_array<DATATYPE, true> &estim)
+double Utils<DATATYPE>::ISE (convert_to_array<DATATYPE, true> &orig, convert_to_array<DATATYPE, true> &estim)
 {
   int dlen = orig.n_elem();
   double sum = 0., temp;
@@ -439,7 +439,7 @@ double Utils<DATATYPE>::binomial (int n, int k, double p)
 }
 
 template <class DATATYPE> 
-void Utils<DATATYPE>::EMMixBinomialParam (double &alpha, double &pa, double &pi, int NExp, to_array<DATATYPE, true> ndet[], int ndlen, int NITER)
+void Utils<DATATYPE>::EMMixBinomialParam (double &alpha, double &pa, double &pi, int NExp, convert_to_array<DATATYPE, true> ndet[], int ndlen, int NITER)
 {
   long N = 0;
   int k;

--- a/src/msvst/libmsvst/Wavelet_msvst.h
+++ b/src/msvst/libmsvst/Wavelet_msvst.h
@@ -20,42 +20,42 @@ class WaveletShrinkage
 		// Hard threshold = k * sigma; sup use -1 / 1 to indicate the insignificant/significant coef. region 
 		// alpha is the preset two-sided p-value of the significance level
 		// alpha as the significance level is returned 
-		double gaussHardThreshold (to_array<DATATYPE, true> &waveletData, \
-			double alpha, double sigma, to_array<SUPTYPE, true> *sup = NULL);
+		double gaussHardThreshold (convert_to_array<DATATYPE, true> &waveletData, \
+			double alpha, double sigma, convert_to_array<SUPTYPE, true> *sup = NULL);
 
 		// Denoise gaussian noise 
 		// Soft threshold = k * sigma; sup use -1 / 1 to indicate the insignificant/significant coef. region 
 		// alpha is the preset two-sided p-value of the significance level
 		// alpha as the significance level is returned 
-		double gaussSoftThreshold (to_array<DATATYPE, true> &waveletData, \
-			double alpha, double sigma, to_array<SUPTYPE, true> *sup = NULL);
+		double gaussSoftThreshold (convert_to_array<DATATYPE, true> &waveletData, \
+			double alpha, double sigma, convert_to_array<SUPTYPE, true> *sup = NULL);
 
 		// Denoise gaussian noise 
 		// FDR threshold; sup use -1 / 1 to indicate the insignificant/significant coef. region
 		// alpha is the preset FDR
       	// the thresholding two-sided p-value is returned 
-		double gaussFDRThreshold (to_array<DATATYPE, true> &waveletData, \
-			double sigma, double alpha, bool indep = true, to_array<SUPTYPE, true> *sup = NULL);            
+		double gaussFDRThreshold (convert_to_array<DATATYPE, true> &waveletData, \
+			double sigma, double alpha, bool indep = true, convert_to_array<SUPTYPE, true> *sup = NULL);            
 
 		// hard threshold in Corrected Coupled MSVST 
-		double ccHardThreshold (to_array<DATATYPE, true> &waveletData, to_array<DATATYPE, true> &appData, int scale, \
-			double alpha, to_array<SUPTYPE, true> *sup = NULL);
+		double ccHardThreshold (convert_to_array<DATATYPE, true> &waveletData, convert_to_array<DATATYPE, true> &appData, int scale, \
+			double alpha, convert_to_array<SUPTYPE, true> *sup = NULL);
 
 		// FDR threshold in Corrected Coupled MSVST
-		double ccFDRThreshold (to_array<DATATYPE, true> &waveletData, to_array<DATATYPE, true> &appData, int scale, \
-			double alpha, bool indep = true, to_array<SUPTYPE, true> *sup = NULL);            
+		double ccFDRThreshold (convert_to_array<DATATYPE, true> &waveletData, convert_to_array<DATATYPE, true> &appData, int scale, \
+			double alpha, bool indep = true, convert_to_array<SUPTYPE, true> *sup = NULL);            
 
 		// hard threshold in direct estimation
-		double dirHardThreshold (to_array<DATATYPE, true> &waveletData, to_array<DATATYPE, true> &appData, int scale, \
-			double alpha, to_array<SUPTYPE, true> *sup = NULL);
+		double dirHardThreshold (convert_to_array<DATATYPE, true> &waveletData, convert_to_array<DATATYPE, true> &appData, int scale, \
+			double alpha, convert_to_array<SUPTYPE, true> *sup = NULL);
 
 		// FDR threshold direct estimation
-		double dirFDRThreshold (to_array<DATATYPE, true> &waveletData, to_array<DATATYPE, true> &appData, int scale, \
-			double alpha, bool indep = true, to_array<SUPTYPE, true> *sup = NULL);            
+		double dirFDRThreshold (convert_to_array<DATATYPE, true> &waveletData, convert_to_array<DATATYPE, true> &appData, int scale, \
+			double alpha, bool indep = true, convert_to_array<SUPTYPE, true> *sup = NULL);            
 };
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussHardThreshold (to_array<DATATYPE, true> &waveletData, double alpha, double sigma, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussHardThreshold (convert_to_array<DATATYPE, true> &waveletData, double alpha, double sigma, convert_to_array<SUPTYPE, true> *sup)
 {
     int dim = waveletData.naxis();
 	int nx = waveletData.nx(), ny = waveletData.ny(), nz = waveletData.nz();
@@ -115,7 +115,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussHardThreshold (to_array<DATATYP
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussSoftThreshold (to_array<DATATYPE, true> &waveletData, double alpha, double sigma, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussSoftThreshold (convert_to_array<DATATYPE, true> &waveletData, double alpha, double sigma, convert_to_array<SUPTYPE, true> *sup)
 {
     int dim = waveletData.naxis();
 	int nx = waveletData.nx(), ny = waveletData.ny(), nz = waveletData.nz();
@@ -188,8 +188,8 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussSoftThreshold (to_array<DATATYP
 	return alpha;
 }
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE, true> &waveletData, \
-					  double sigma, double alpha, bool indep, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (convert_to_array<DATATYPE, true> &waveletData, \
+					  double sigma, double alpha, bool indep, convert_to_array<SUPTYPE, true> *sup)
 {
   int dim = waveletData.naxis();
   int nx = waveletData.nx(), ny = waveletData.ny(), nz = waveletData.nz();
@@ -198,7 +198,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE
   if (dim == 1)
     {
       if (sup != NULL) sup->resize(nx);
-      to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx);
+      convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx);
       for (int x=0; x<nx; x++)
 	  {
 	  if (sigma < 1e-20) (*pvals)(x) = 0;
@@ -228,7 +228,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE
   else if (dim == 2)
     {
       if (sup != NULL) sup->resize(nx, ny);
-      to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny);
+      convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny);
       for (int x=0; x<nx; x++)
       for (int y=0; y<ny; y++)
 	  {
@@ -260,7 +260,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE
   else if (dim == 3)
     {
       if (sup != NULL) sup->resize(nx, ny, nz);
-      to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny, nz);
+      convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny, nz);
       for (int x=0; x<nx; x++)
       for (int y=0; y<ny; y++)
       for (int z=0; z<nz; z++)
@@ -297,8 +297,8 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::ccHardThreshold (to_array<DATATYPE, true> &waveletData, to_array<DATATYPE, true> &appData, int scale, \
-			double alpha, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::ccHardThreshold (convert_to_array<DATATYPE, true> &waveletData, convert_to_array<DATATYPE, true> &appData, int scale, \
+			double alpha, convert_to_array<SUPTYPE, true> *sup)
 {
     int dim = waveletData.naxis();
 	int nx = waveletData.nx(), ny = waveletData.ny(), nz = waveletData.nz();
@@ -329,8 +329,8 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::ccHardThreshold (to_array<DATATYPE, 
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::ccFDRThreshold (to_array<DATATYPE, true> &waveletData, to_array<DATATYPE, true> &appData, int scale, \
-                       double alpha, bool indep, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::ccFDRThreshold (convert_to_array<DATATYPE, true> &waveletData, convert_to_array<DATATYPE, true> &appData, int scale, \
+                       double alpha, bool indep, convert_to_array<SUPTYPE, true> *sup)
 {
   int dim = waveletData.naxis();
   int nx = waveletData.nx(), ny = waveletData.ny(), nz = waveletData.nz();
@@ -339,7 +339,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::ccFDRThreshold (to_array<DATATYPE, t
 
 
   if (sup != NULL) sup->resize(nx, ny, nz);
-  to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny, nz);
+  convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny, nz);
   for (int x=0; x<len; x++)
   {
     coefa = MAX(appData(x), 0.);
@@ -375,8 +375,8 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::ccFDRThreshold (to_array<DATATYPE, t
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::dirHardThreshold (to_array<DATATYPE, true> &waveletData, to_array<DATATYPE, true> &appData, int scale, \
-			double alpha, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::dirHardThreshold (convert_to_array<DATATYPE, true> &waveletData, convert_to_array<DATATYPE, true> &appData, int scale, \
+			double alpha, convert_to_array<SUPTYPE, true> *sup)
 {
     int dim = waveletData.naxis();
 	int nx = waveletData.nx(), ny = waveletData.ny(), nz = waveletData.nz();
@@ -405,8 +405,8 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::dirHardThreshold (to_array<DATATYPE,
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::dirFDRThreshold (to_array<DATATYPE, true> &waveletData, to_array<DATATYPE, true> &appData, int scale, \
-                       double alpha, bool indep, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::dirFDRThreshold (convert_to_array<DATATYPE, true> &waveletData, convert_to_array<DATATYPE, true> &appData, int scale, \
+                       double alpha, bool indep, convert_to_array<SUPTYPE, true> *sup)
 {
   int dim = waveletData.naxis();
   int nx = waveletData.nx(), ny = waveletData.ny(), nz = waveletData.nz();
@@ -415,7 +415,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::dirFDRThreshold (to_array<DATATYPE, 
 
 
   if (sup != NULL) sup->resize(nx, ny, nz);
-  to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny, nz);
+  convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny, nz);
   for (int x=0; x<len; x++)
   {
     coefa = MAX(appData(x), 0.);
@@ -496,17 +496,17 @@ class OrthogonalWaveletTransform
 		// (I)DWT 1D along a certain axis
 		// only used by (I)DWT3D
 		// axis = 0, 1, 2 : X, Y, Z
-		static void transformXYZ (to_array<DATATYPE, true> &data, dblarray &dfilterh, dblarray &dfilterg, to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int axis, type_border BORDERTYPE);
-		static void reconstructionXYZ (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, dblarray &rfilterh, dblarray &rfilterg, to_array<DATATYPE, true> &data, int axis);
+		static void transformXYZ (convert_to_array<DATATYPE, true> &data, dblarray &dfilterh, dblarray &dfilterg, convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int axis, type_border BORDERTYPE);
+		static void reconstructionXYZ (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, dblarray &rfilterh, dblarray &rfilterg, convert_to_array<DATATYPE, true> &data, int axis);
 		
 	public:
 		// orthogonal wavelet types
 		static const int HAAR=0, DAUB4=4, SYML4=16;
 		
 		// resize the data to the same size of the reference
-		static void resizeData (to_array<DATATYPE, true> &data, to_array<DATATYPE, true> &ref, type_border BORDERTYPE=I_ZERO);
+		static void resizeData (convert_to_array<DATATYPE, true> &data, convert_to_array<DATATYPE, true> &ref, type_border BORDERTYPE=I_ZERO);
 		// resize the data to [nx], [nx, ny] or [nx, ny, nz] according to the dimension of the data
-		static void resizeData (to_array<DATATYPE, true> &data, int nx, int ny, int nz, type_border BORDERTYPE=I_ZERO);
+		static void resizeData (convert_to_array<DATATYPE, true> &data, int nx, int ny, int nz, type_border BORDERTYPE=I_ZERO);
 		
 		// get the decomposition filters, i.e. \bar{h}, \bar{g}
 		// where h is considered to start from the origin
@@ -515,88 +515,88 @@ class OrthogonalWaveletTransform
 		static void getWaveletReconsFilter (int filterName, dblarray &rfilterh, dblarray &rfilterg);
 		
 		// DWT 1D
-		static void dwt1D (to_array<DATATYPE, true> &data, \
+		static void dwt1D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE=I_MIRROR);
-		static void dwt1D (to_array<DATATYPE, true> &data, \
+		static void dwt1D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE=I_MIRROR);
 		
 		// IDWT 1D 
-		static void idwt1D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+		static void idwt1D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data);
-		static void idwt1D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &data);
+		static void idwt1D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			int filterName, \
-			to_array<DATATYPE, true> &data);			
+			convert_to_array<DATATYPE, true> &data);			
 
 		// DWT 2D
-		static void dwt2D (to_array<DATATYPE, true> &data, \
+		static void dwt2D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE=I_MIRROR);
-		static void dwt2D (to_array<DATATYPE, true> &data, \
+		static void dwt2D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE=I_MIRROR);
 					
 		// IDWT 2D 
-		static void idwt2D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+		static void idwt2D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data);
-		static void idwt2D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &data);
+		static void idwt2D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			int filterName, \
-			to_array<DATATYPE, true> &data);
+			convert_to_array<DATATYPE, true> &data);
 
 		// DWT 3D
-		static void dwt3D (to_array<DATATYPE, true> &data, \
+		static void dwt3D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			type_border BORDERTYPE=I_MIRROR);
-		static void dwt3D (to_array<DATATYPE, true> &data, \
+		static void dwt3D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			type_border BORDERTYPE=I_MIRROR);
 					
 		// IDWT 3D 
 		static void idwt3D ( \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data);
+			convert_to_array<DATATYPE, true> &data);
 		static void idwt3D ( \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			int filterName, \
-			to_array<DATATYPE, true> &data);
+			convert_to_array<DATATYPE, true> &data);
 };
 
 template <class DATATYPE>
@@ -609,19 +609,19 @@ template <class DATATYPE>
 const int OrthogonalWaveletTransform<DATATYPE>::SYML4;
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::resizeData(to_array<DATATYPE, true> &data, to_array<DATATYPE, true> &ref, type_border BORDERTYPE)
+void OrthogonalWaveletTransform<DATATYPE>::resizeData(convert_to_array<DATATYPE, true> &data, convert_to_array<DATATYPE, true> &ref, type_border BORDERTYPE)
 {
 	resizeData(data, ref.nx(), ref.ny(), ref.nz(), BORDERTYPE);
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::resizeData(to_array<DATATYPE, true> &data, int nx, int ny, int nz, type_border BORDERTYPE)
+void OrthogonalWaveletTransform<DATATYPE>::resizeData(convert_to_array<DATATYPE, true> &data, int nx, int ny, int nz, type_border BORDERTYPE)
 {
 	int dnx = data.nx(), dny = data.ny(), dnz = data.nz();
 	if ((nx == dnx) && (ny == dny) && (nz == dnz)) return;
 	int dim = data.naxis();
 
-	to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(dnx, dny, dnz);
+	convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(dnx, dny, dnz);
 	*temp = data;
 	if (dim == 1)
 	{
@@ -704,9 +704,9 @@ void OrthogonalWaveletTransform<DATATYPE>::getWaveletReconsFilter (int filterNam
 }
 
 template <class DATATYPE>
-void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true> &data, dblarray &dfilterh, dblarray &dfilterg, to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int axis, type_border BORDERTYPE)
+void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (convert_to_array<DATATYPE, true> &data, dblarray &dfilterh, dblarray &dfilterg, convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int axis, type_border BORDERTYPE)
 {
-	to_array<DATATYPE, true> *line = NULL, *linea = NULL, *lined = NULL;
+	convert_to_array<DATATYPE, true> *line = NULL, *linea = NULL, *lined = NULL;
 	int lenx, leny, lenz, dlenx, dleny, dlenz;
 	
 	if (axis == 0)
@@ -715,9 +715,9 @@ void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true
 		dlenx = getDecompResultLength(lenx, dfilterh.n_elem());
 		ca.resize(dlenx, leny, lenz);
 		cd.resize(dlenx, leny, lenz);
-		line = new to_array<DATATYPE, true>(lenx);
-		linea = new to_array<DATATYPE, true>(dlenx);
-		lined = new to_array<DATATYPE, true>(dlenx);
+		line = new convert_to_array<DATATYPE, true>(lenx);
+		linea = new convert_to_array<DATATYPE, true>(dlenx);
+		lined = new convert_to_array<DATATYPE, true>(dlenx);
 		
 		for (int z=0; z<lenz; z++)
 		for (int y=0; y<leny; y++)
@@ -738,9 +738,9 @@ void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true
 		dleny = getDecompResultLength(leny, dfilterh.n_elem());
 		ca.resize(lenx, dleny, lenz);
 		cd.resize(lenx, dleny, lenz);
-		line = new to_array<DATATYPE, true>(leny);
-		linea = new to_array<DATATYPE, true>(dleny);
-		lined = new to_array<DATATYPE, true>(dleny);
+		line = new convert_to_array<DATATYPE, true>(leny);
+		linea = new convert_to_array<DATATYPE, true>(dleny);
+		lined = new convert_to_array<DATATYPE, true>(dleny);
 
 		for (int z=0; z<lenz; z++)
 		for (int x=0; x<lenx; x++)
@@ -761,9 +761,9 @@ void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true
 		dlenz = getDecompResultLength(lenz, dfilterh.n_elem());	
 		ca.resize(lenx, leny, dlenz);
 		cd.resize(lenx, leny, dlenz);
-		line = new to_array<DATATYPE, true>(lenz);
-		linea = new to_array<DATATYPE, true>(dlenz);
-		lined = new to_array<DATATYPE, true>(dlenz);
+		line = new convert_to_array<DATATYPE, true>(lenz);
+		linea = new convert_to_array<DATATYPE, true>(dlenz);
+		lined = new convert_to_array<DATATYPE, true>(dlenz);
 
 		for (int y=0; y<leny; y++)
 		for (int x=0; x<lenx; x++)
@@ -786,18 +786,18 @@ void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true
 }
 
 template <class DATATYPE>
-void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, dblarray &rfilterh, dblarray &rfilterg, to_array<DATATYPE, true> &data, int axis)
+void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, dblarray &rfilterh, dblarray &rfilterg, convert_to_array<DATATYPE, true> &data, int axis)
 {
-	to_array<DATATYPE, true> *line = NULL, *linea = NULL, *lined = NULL;
+	convert_to_array<DATATYPE, true> *line = NULL, *linea = NULL, *lined = NULL;
 	int lenx, leny, lenz, rlenx, rleny, rlenz;
 	
 	if (axis == 0)
 	{
 		lenx = ca.nx(); leny = ca.ny(); lenz = ca.nz();
 		rlenx = getReconsResultLength(lenx, rfilterh.n_elem());
-		line = new to_array<DATATYPE, true>(rlenx);
-		linea = new to_array<DATATYPE, true>(lenx);
-		lined = new to_array<DATATYPE, true>(lenx);
+		line = new convert_to_array<DATATYPE, true>(rlenx);
+		linea = new convert_to_array<DATATYPE, true>(lenx);
+		lined = new convert_to_array<DATATYPE, true>(lenx);
 		data.resize(rlenx, leny, lenz);
 		
 		for (int z=0; z<lenz; z++)
@@ -817,9 +817,9 @@ void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (to_array<DATATYPE,
 	{
 		lenx = ca.nx(); leny = ca.ny(); lenz = ca.nz();
 		rleny = getReconsResultLength(leny, rfilterh.n_elem());
-		line = new to_array<DATATYPE, true>(rleny);
-		linea = new to_array<DATATYPE, true>(leny);
-		lined = new to_array<DATATYPE, true>(leny);
+		line = new convert_to_array<DATATYPE, true>(rleny);
+		linea = new convert_to_array<DATATYPE, true>(leny);
+		lined = new convert_to_array<DATATYPE, true>(leny);
 		data.resize(lenx, rleny, lenz);
 		
 		for (int z=0; z<lenz; z++)
@@ -839,9 +839,9 @@ void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (to_array<DATATYPE,
 	{
 		lenx = ca.nx(); leny = ca.ny(); lenz = ca.nz();
 		rlenz = getReconsResultLength(lenz, rfilterh.n_elem());
-		line = new to_array<DATATYPE, true>(rlenz);
-		linea = new to_array<DATATYPE, true>(lenz);
-		lined = new to_array<DATATYPE, true>(lenz);
+		line = new convert_to_array<DATATYPE, true>(rlenz);
+		linea = new convert_to_array<DATATYPE, true>(lenz);
+		lined = new convert_to_array<DATATYPE, true>(lenz);
 		data.resize(lenx, leny, rlenz);
 		
 		for (int y=0; y<leny; y++)
@@ -865,9 +865,9 @@ void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (to_array<DATATYPE,
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::dwt1D (to_array<DATATYPE, true> &data, \
+void OrthogonalWaveletTransform<DATATYPE>::dwt1D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE)
 {
 	int datalen = data.nx();
@@ -897,9 +897,9 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt1D (to_array<DATATYPE, true> &data
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::dwt1D (to_array<DATATYPE, true> &data, \
+void OrthogonalWaveletTransform<DATATYPE>::dwt1D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE)
 {
 	dblarray filterh, filterg;
@@ -908,9 +908,9 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt1D (to_array<DATATYPE, true> &data
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::idwt1D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+void OrthogonalWaveletTransform<DATATYPE>::idwt1D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	int calen = ca.nx(), cdlen = cd.nx();
 	if (calen != cdlen)
@@ -943,9 +943,9 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt1D (to_array<DATATYPE, true> &ca,
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::idwt1D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+void OrthogonalWaveletTransform<DATATYPE>::idwt1D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			int filterName, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	dblarray filterh, filterg;
 	getWaveletReconsFilter(filterName, filterh, filterg);
@@ -953,9 +953,9 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt1D (to_array<DATATYPE, true> &ca,
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data, \
+void OrthogonalWaveletTransform<DATATYPE>::dwt2D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE)
 {
 	int datalenx = data.nx(), dataleny = data.ny();
@@ -967,11 +967,11 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data
 	ca.resize(reslenx, resleny); 	ch.resize(reslenx, resleny);
 	cv.resize(reslenx, resleny); 	cd.resize(reslenx, resleny);
 
-	to_array<DATATYPE, true> *temph = new to_array<DATATYPE, true>(reslenx, dataleny);
-	to_array<DATATYPE, true> *tempg = new to_array<DATATYPE, true>(reslenx, dataleny);
-	to_array<DATATYPE, true> *line = new to_array<DATATYPE, true>(datalenx);
-	to_array<DATATYPE, true> *atempline = new to_array<DATATYPE, true>(reslenx);
-	to_array<DATATYPE, true> *dtempline = new to_array<DATATYPE, true>(reslenx);
+	convert_to_array<DATATYPE, true> *temph = new convert_to_array<DATATYPE, true>(reslenx, dataleny);
+	convert_to_array<DATATYPE, true> *tempg = new convert_to_array<DATATYPE, true>(reslenx, dataleny);
+	convert_to_array<DATATYPE, true> *line = new convert_to_array<DATATYPE, true>(datalenx);
+	convert_to_array<DATATYPE, true> *atempline = new convert_to_array<DATATYPE, true>(reslenx);
+	convert_to_array<DATATYPE, true> *dtempline = new convert_to_array<DATATYPE, true>(reslenx);
 	for (int y=0; y<dataleny; y++)
 	{
 		for (int x=0; x<datalenx; x++) (*line)(x) = data(x,y);
@@ -986,10 +986,10 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data
 	if (atempline != NULL) { delete atempline; atempline = NULL; }
 	if (dtempline != NULL) { delete dtempline; dtempline = NULL; }
 	
-	to_array<DATATYPE, true> *col1 = new to_array<DATATYPE, true>(dataleny);
-	to_array<DATATYPE, true> *col2 = new to_array<DATATYPE, true>(dataleny);
-	to_array<DATATYPE, true> *atempcol = new to_array<DATATYPE, true>(resleny);
-	to_array<DATATYPE, true> *dtempcol = new to_array<DATATYPE, true>(resleny);
+	convert_to_array<DATATYPE, true> *col1 = new convert_to_array<DATATYPE, true>(dataleny);
+	convert_to_array<DATATYPE, true> *col2 = new convert_to_array<DATATYPE, true>(dataleny);
+	convert_to_array<DATATYPE, true> *atempcol = new convert_to_array<DATATYPE, true>(resleny);
+	convert_to_array<DATATYPE, true> *dtempcol = new convert_to_array<DATATYPE, true>(resleny);
 	for (int x=0; x<reslenx; x++)
 	{
 		for (int y=0; y<dataleny; y++)
@@ -1019,9 +1019,9 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data, \
+void OrthogonalWaveletTransform<DATATYPE>::dwt2D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE)
 {
 	dblarray filterh, filterg;
@@ -1030,9 +1030,9 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+void OrthogonalWaveletTransform<DATATYPE>::idwt2D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	int calenx = ca.nx(), caleny = ca.ny();
 	int chlenx = ch.nx(), chleny = ch.ny();
@@ -1049,14 +1049,14 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca,
 	int resleny = getReconsResultLength(caleny, hlen);
 	data.resize(reslenx, resleny);
 
-	to_array<DATATYPE, true> *temph = new to_array<DATATYPE, true>(calenx, resleny);
-	to_array<DATATYPE, true> *tempg = new to_array<DATATYPE, true>(calenx, resleny);
-	to_array<DATATYPE, true> *cola = new to_array<DATATYPE, true>(caleny);
-	to_array<DATATYPE, true> *colh = new to_array<DATATYPE, true>(chleny);
-	to_array<DATATYPE, true> *colv = new to_array<DATATYPE, true>(cvleny);
-	to_array<DATATYPE, true> *cold = new to_array<DATATYPE, true>(cdleny);
-	to_array<DATATYPE, true> *coltemph = new to_array<DATATYPE, true>(resleny);	
-	to_array<DATATYPE, true> *coltempg = new to_array<DATATYPE, true>(resleny);	
+	convert_to_array<DATATYPE, true> *temph = new convert_to_array<DATATYPE, true>(calenx, resleny);
+	convert_to_array<DATATYPE, true> *tempg = new convert_to_array<DATATYPE, true>(calenx, resleny);
+	convert_to_array<DATATYPE, true> *cola = new convert_to_array<DATATYPE, true>(caleny);
+	convert_to_array<DATATYPE, true> *colh = new convert_to_array<DATATYPE, true>(chleny);
+	convert_to_array<DATATYPE, true> *colv = new convert_to_array<DATATYPE, true>(cvleny);
+	convert_to_array<DATATYPE, true> *cold = new convert_to_array<DATATYPE, true>(cdleny);
+	convert_to_array<DATATYPE, true> *coltemph = new convert_to_array<DATATYPE, true>(resleny);	
+	convert_to_array<DATATYPE, true> *coltempg = new convert_to_array<DATATYPE, true>(resleny);	
 	for (int x=0; x<calenx; x++)
 	{
 		for (int y=0; y<caleny; y++)
@@ -1081,9 +1081,9 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca,
 	if (coltemph != NULL) { delete coltemph; coltemph = NULL; }
 	if (coltempg != NULL) { delete coltempg; coltempg = NULL; }
 	
-	to_array<DATATYPE, true> *lineh = new to_array<DATATYPE, true>(calenx);	
-	to_array<DATATYPE, true> *lineg = new to_array<DATATYPE, true>(calenx);	
-	to_array<DATATYPE, true> *line = new to_array<DATATYPE, true>(reslenx);	
+	convert_to_array<DATATYPE, true> *lineh = new convert_to_array<DATATYPE, true>(calenx);	
+	convert_to_array<DATATYPE, true> *lineg = new convert_to_array<DATATYPE, true>(calenx);	
+	convert_to_array<DATATYPE, true> *line = new convert_to_array<DATATYPE, true>(reslenx);	
 	for (int y=0; y<resleny; y++)
 	{
 		for (int x=0; x<calenx; x++)
@@ -1103,9 +1103,9 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca,
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+void OrthogonalWaveletTransform<DATATYPE>::idwt2D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			int filterName, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	dblarray filterh, filterg;
 	getWaveletReconsFilter(filterName, filterh, filterg);
@@ -1114,16 +1114,16 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca,
 
 template <class DATATYPE>
 void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
-			to_array<DATATYPE, true> &data, \
+			convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			type_border BORDERTYPE)
 {
 	int hlen = dfilterh.n_elem(), glen = dfilterg.n_elem();
@@ -1139,18 +1139,18 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
 	cggh.resize(reslenx, resleny, reslenz); cggg.resize(reslenx, resleny, reslenz);
 
 	// X
-	to_array<DATATYPE, true> *temph = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temph = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempg = new convert_to_array<DATATYPE, true>;
 	transformXYZ(data, dfilterh, dfilterg, *temph, *tempg, 0, BORDERTYPE);
 	
 	// Y
-	to_array<DATATYPE, true> *temphh = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *temphg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temphh = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temphg = new convert_to_array<DATATYPE, true>;
 	transformXYZ(*temph, dfilterh, dfilterg, *temphh, *temphg, 1, BORDERTYPE);
 	if (temph != NULL) { delete temph; temph = NULL; }
 	
-	to_array<DATATYPE, true> *tempgh = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempgg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempgh = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempgg = new convert_to_array<DATATYPE, true>;
 	transformXYZ(*tempg, dfilterh, dfilterg, *tempgh, *tempgg, 1, BORDERTYPE);
 	if (tempg != NULL) { delete tempg; tempg = NULL; }
 	
@@ -1168,16 +1168,16 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
 
 template <class DATATYPE>
 void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
-			to_array<DATATYPE, true> &data, \
+			convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			type_border BORDERTYPE)
 {
 	dblarray filterh, filterg;
@@ -1187,16 +1187,16 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
 
 template <class DATATYPE>
 void OrthogonalWaveletTransform<DATATYPE>::idwt3D ( \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	int hlen = rfilterh.n_elem(), glen = rfilterg.n_elem();
 	if (hlen != glen)
@@ -1223,18 +1223,18 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt3D ( \
 	data.resize(reslenx, resleny, reslenz);
 	
 	// Z
-	to_array<DATATYPE, true> *temphh = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *temphg = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempgh = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempgg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temphh = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temphg = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempgh = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempgg = new convert_to_array<DATATYPE, true>;
 	reconstructionXYZ(ca, chhg, rfilterh, rfilterg, *temphh, 2);
 	reconstructionXYZ(chgh, chgg, rfilterh, rfilterg, *temphg, 2);
 	reconstructionXYZ(cghh, cghg, rfilterh, rfilterg, *tempgh, 2);
 	reconstructionXYZ(cggh, cggg, rfilterh, rfilterg, *tempgg, 2);
 	
 	// Y
-	to_array<DATATYPE, true> *temph = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temph = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempg = new convert_to_array<DATATYPE, true>;
 	reconstructionXYZ(*temphh, *temphg, rfilterh, rfilterg, *temph, 1);
 	if (temphh != NULL) { delete temphh; temphh = NULL; }
 	if (temphg != NULL) { delete temphg; temphg = NULL; }
@@ -1251,16 +1251,16 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt3D ( \
 
 template <class DATATYPE>
 void OrthogonalWaveletTransform<DATATYPE>::idwt3D ( \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			int filterName, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	dblarray filterh, filterg;
 	getWaveletReconsFilter(filterName, filterh, filterg);

--- a/src/msvst/msvstmain/msvst_2d1d.cc
+++ b/src/msvst/msvstmain/msvst_2d1d.cc
@@ -293,7 +293,7 @@ int scaleOfData (int dim, int nx, int ny, int nz)
 
 // display the content of a data array (useful in debug mode)
 template <typename DATATYPE>
-void display (to_array<DATATYPE, true> &data)
+void display (convert_to_array<DATATYPE, true> &data)
 {
 	int dim = data.naxis();
 	if (VERBOSE)
@@ -333,7 +333,7 @@ void display (to_array<DATATYPE, true> &data)
 }
 
 template <typename DATATYPE>
-void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, double cst)
+void setConst (convert_to_array<DATATYPE, true> &dest, convert_to_array<DATATYPE, true> &ref, double cst)
 {
 	int nx = ref.nx(), ny = ref.ny(), nz = ref.nz();
 	int len = ref.n_elem();
@@ -345,7 +345,7 @@ void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, do
 
 // denoise a band
 template <typename SUPTYPE>
-void bandDenoise(fltarray &band, double sigma, to_array<SUPTYPE, true> *ms, int sxy, int sz)
+void bandDenoise(fltarray &band, double sigma, convert_to_array<SUPTYPE, true> *ms, int sxy, int sz)
 {
 	WaveletShrinkage<float, SUPTYPE> ws;
 	double pr, fdrp; // threshold p-value and FDR-threshold p-value
@@ -389,7 +389,7 @@ void bandDenoise(fltarray &band, double sigma, to_array<SUPTYPE, true> *ms, int 
 
 // B3 Wavelet denoising - general process
 template <typename SUPTYPE>
-void b3SplineDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup)
+void b3SplineDenoise (fltarray &data, convert_to_array<SUPTYPE, true> *multiSup)
 {
     double sigma;
     double corr;
@@ -491,7 +491,7 @@ void b3SplineDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup)
 
 // for different modes of iteration
 template <typename SUPTYPE>
-void procArr (fltarray &origdata, fltarray &data, to_array<SUPTYPE, true> &coef, double lambda, int itr)
+void procArr (fltarray &origdata, fltarray &data, convert_to_array<SUPTYPE, true> &coef, double lambda, int itr)
 {
   int n = data.n_elem();
 

--- a/src/msvst/msvstmain/msvst_iwt2d.cc
+++ b/src/msvst/msvstmain/msvst_iwt2d.cc
@@ -248,7 +248,7 @@ int scaleOfData (int dim, int nx, int ny, int nz)
 
 // display the content of a data array (useful in debug mode)
 template <typename DATATYPE>
-void display (to_array<DATATYPE, true> &data)
+void display (convert_to_array<DATATYPE, true> &data)
 {
 	int dim = data.naxis();
 	if (VERBOSE)
@@ -288,7 +288,7 @@ void display (to_array<DATATYPE, true> &data)
 }
 
 template <typename DATATYPE>
-void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, double cst)
+void setConst (convert_to_array<DATATYPE, true> &dest, convert_to_array<DATATYPE, true> &ref, double cst)
 {
 	int nx = ref.nx(), ny = ref.ny(), nz = ref.nz();
 	int len = ref.n_elem();
@@ -300,7 +300,7 @@ void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, do
 
 // Wavelet denoising - general process
 template <typename SUPTYPE>
-void b3SplineDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup)
+void b3SplineDenoise (fltarray &data, convert_to_array<SUPTYPE, true> *multiSup)
 {
 	int dim = data.naxis();
 	double pr, fdrp; // threshold p-value and FDR-threshold p-value
@@ -354,7 +354,7 @@ void b3SplineDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup)
 
 // for different modes of iteration
 template <typename SUPTYPE>
-void procArr (fltarray &origdata, fltarray &data, to_array<SUPTYPE, true> &coef, double lambda, int itr)
+void procArr (fltarray &origdata, fltarray &data, convert_to_array<SUPTYPE, true> &coef, double lambda, int itr)
 {
   int n = data.n_elem();
 

--- a/src/msvst/msvstmain/msvst_iwt2d_coupled.cc
+++ b/src/msvst/msvstmain/msvst_iwt2d_coupled.cc
@@ -280,7 +280,7 @@ int scaleOfData (int dim, int nx, int ny, int nz)
 
 // display the content of a data array (useful in debug mode)
 template <typename DATATYPE>
-void display (to_array<DATATYPE, true> &data)
+void display (convert_to_array<DATATYPE, true> &data)
 {
 	int dim = data.naxis();
 	if (VERBOSE)
@@ -320,7 +320,7 @@ void display (to_array<DATATYPE, true> &data)
 }
 
 template <typename DATATYPE>
-void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, double cst)
+void setConst (convert_to_array<DATATYPE, true> &dest, convert_to_array<DATATYPE, true> &ref, double cst)
 {
 	int nx = ref.nx(), ny = ref.ny(), nz = ref.nz();
 	int len = ref.n_elem();
@@ -332,7 +332,7 @@ void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, do
 
 // Wavelet denoising - general process
 template <typename SUPTYPE>
-void b3SplineDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup)
+void b3SplineDenoise (fltarray &data, convert_to_array<SUPTYPE, true> *multiSup)
 {
 	int dim = data.naxis();
 	double pr, fdrp; // threshold p-value and FDR-threshold p-value
@@ -420,7 +420,7 @@ void b3SplineDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup)
 
 // for different modes of iteration
 template <typename SUPTYPE>
-void procArr (fltarray &origdata, fltarray &data, to_array<SUPTYPE, true> &coef, double lambda)
+void procArr (fltarray &origdata, fltarray &data, convert_to_array<SUPTYPE, true> &coef, double lambda)
 {
   int n = data.n_elem();
 

--- a/src/msvst/msvstmain/msvst_uwt2d.cc
+++ b/src/msvst/msvstmain/msvst_uwt2d.cc
@@ -221,7 +221,7 @@ int scaleOfData (int dim, int nx, int ny, int nz)
 
 // display the content of a data array (useful in debug mode)
 template <typename DATATYPE>
-void display (to_array<DATATYPE, true> &data)
+void display (convert_to_array<DATATYPE, true> &data)
 {
 	int dim = data.naxis();
 	if (VERBOSE)
@@ -261,7 +261,7 @@ void display (to_array<DATATYPE, true> &data)
 }
 
 template <typename DATATYPE>
-void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, double cst)
+void setConst (convert_to_array<DATATYPE, true> &dest, convert_to_array<DATATYPE, true> &ref, double cst)
 {
 	int nx = ref.nx(), ny = ref.ny(), nz = ref.nz();
 	int len = ref.n_elem();
@@ -275,7 +275,7 @@ void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, do
 // maxlen is the max. length of the filters
 // this function garantees the even number of samples along each direction when decimated transform is used.
 template <typename DATATYPE>
-void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYPE, int scale, bool dec[], int ext[6])
+void extData(convert_to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYPE, int scale, bool dec[], int ext[6])
 {
   int nx = data.nx(), ny = data.ny(), nz = data.nz();
   int dim = data.naxis();
@@ -309,7 +309,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
     {
       int newlen = nx + lext + rext;
       if ((newlen % 2 != 0) && dec[0]) { newlen++; ext[1]++; rext++; }
-      to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen);
+      convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen);
 
       for (int x=0; x<newlen; x++)
 	  (*temp)(x) = data(x-lext, BORDERTYPE);
@@ -322,7 +322,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
       if ((newlen1 % 2 != 0) && dec[0]) { newlen1++; ext[1]++; rext++; }
       if ((newlen2 % 2 != 0) && dec[1]) { newlen2++; ext[3]++; dext++; }
 
-      to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen1, newlen2);
+      convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen1, newlen2);
       for (int y=0; y<newlen2; y++)
 	for (int x=0; x<newlen1; x++)
 	  (*temp)(x, y) = data(x-lext, y-uext, BORDERTYPE);
@@ -336,7 +336,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
       if ((newlen2 % 2 != 0) && dec[1]) { newlen2++; ext[3]++; dext++; }
       if ((newlen3 % 2 != 0) && dec[2]) { newlen3++; ext[5]++; fext++; }
       
-      to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen1, newlen2, newlen3);
+      convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen1, newlen2, newlen3);
       for (int z=0; z<newlen3; z++)
 	for (int y=0; y<newlen2; y++)
 	  for (int x=0; x<newlen1; x++)
@@ -348,7 +348,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
 
 // extract the data from the extension version
 template <typename DATATYPE>
-void extractData (to_array<DATATYPE, true> &data, int ext[6])
+void extractData (convert_to_array<DATATYPE, true> &data, int ext[6])
 {
   int dim = data.naxis();
   int lext = ext[0], rext = ext[1], uext = ext[2];
@@ -357,7 +357,7 @@ void extractData (to_array<DATATYPE, true> &data, int ext[6])
   if ((dim == 1) && ((lext != 0) || (rext != 0)))
     {
       int finallen = data.nx() - lext - rext;
-      to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen);
+      convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen);
       for (int x=0; x<finallen; x++) (*tdata)(x) = data(lext+x);
       data = (*tdata);
       delete tdata; tdata = NULL;
@@ -367,7 +367,7 @@ void extractData (to_array<DATATYPE, true> &data, int ext[6])
     {
       int finallen1 = data.nx() - lext - rext;
       int finallen2 = data.ny() - uext - dext;
-      to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen1, finallen2);
+      convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen1, finallen2);
       for (int x=0; x<finallen1; x++) 
 	for (int y=0; y<finallen2; y++)
 	  (*tdata)(x, y) = data(lext+x, uext+y);
@@ -381,7 +381,7 @@ void extractData (to_array<DATATYPE, true> &data, int ext[6])
       int finallen1 = data.nx() - lext - rext;
       int finallen2 = data.ny() - uext - dext;
       int finallen3 = data.nz() - bext - fext;
-      to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen1, finallen2, finallen3);
+      convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen1, finallen2, finallen3);
       for (int x=0; x<finallen1; x++) 
 	  for (int y=0; y<finallen2; y++)
 	  for (int z=0; z<finallen3; z++)	
@@ -445,7 +445,7 @@ void cycleTrans (fltarray &data, int dx, int dy, int dz)
 }
 
 template <typename DATATYPE>
-void msvst (to_array<DATATYPE, true> &data, to_array<DATATYPE, true> &vstData, int scale)
+void msvst (convert_to_array<DATATYPE, true> &data, convert_to_array<DATATYPE, true> &vstData, int scale)
 {
      double b, c;
      int dim = data.naxis();
@@ -464,7 +464,7 @@ void msvst (to_array<DATATYPE, true> &data, to_array<DATATYPE, true> &vstData, i
 // Wavelet denoising - general process
 template <typename SUPTYPE>
 void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
-		             to_array<SUPTYPE, true> *multiSup = NULL)
+		             convert_to_array<SUPTYPE, true> *multiSup = NULL)
 {
 	int dim = data.naxis();
 	int ext[NSCALE][6];
@@ -848,7 +848,7 @@ void fiszDenoise (fltarray &data, int DX, int DY, int DZ)
 }
 
 template <typename SUPTYPE>
-void procArr (fltarray &origdata, fltarray &data, to_array<SUPTYPE, true> &coef, double lambda, int itr)
+void procArr (fltarray &origdata, fltarray &data, convert_to_array<SUPTYPE, true> &coef, double lambda, int itr)
 {
   int n = data.n_elem();
 

--- a/src/mwir/libmwir/Fisz.h
+++ b/src/mwir/libmwir/Fisz.h
@@ -22,27 +22,27 @@ class FiszTransform
 		// dimension of the nearest power of two,
 		// if the data size is not of power two;
 		// ext is an array of 6 elements (extension information of 6 directions)
-		void dataExtension (to_array<DATATYPE, true> &data, int ext[], type_border BORDERTYPE=I_MIRROR);
+		void dataExtension (convert_to_array<DATATYPE, true> &data, int ext[], type_border BORDERTYPE=I_MIRROR);
 		// extract the original data in using the extension information
-		void dataExtraction (to_array<DATATYPE, true> &data, int ext[]);
+		void dataExtraction (convert_to_array<DATATYPE, true> &data, int ext[]);
 		
 		// Fisz transform 1D / 2D / 3D
 		// the data size MUST be power of two, 
 		// otherwise, a DataSizeException will be thrown out
-		void fisz1D (to_array<DATATYPE, true> &data);
-		void fisz2D (to_array<DATATYPE, true> &data);
-		void fisz3D (to_array<DATATYPE, true> &data);
+		void fisz1D (convert_to_array<DATATYPE, true> &data);
+		void fisz2D (convert_to_array<DATATYPE, true> &data);
+		void fisz3D (convert_to_array<DATATYPE, true> &data);
 
 		// Inverse Fisz transform 1D / 2D / 3D
 		// data size MUST be power of two.
 		// otherwise, a DataSizeException will be thrown out
-		void ifisz1D (to_array<DATATYPE, true> &data);
-		void ifisz2D (to_array<DATATYPE, true> &data);
-		void ifisz3D (to_array<DATATYPE, true> &data);
+		void ifisz1D (convert_to_array<DATATYPE, true> &data);
+		void ifisz2D (convert_to_array<DATATYPE, true> &data);
+		void ifisz3D (convert_to_array<DATATYPE, true> &data);
 };
 
 template <class DATATYPE>
-void FiszTransform<DATATYPE>::dataExtension (to_array<DATATYPE, true> &data, int ext[], type_border BORDERTYPE)
+void FiszTransform<DATATYPE>::dataExtension (convert_to_array<DATATYPE, true> &data, int ext[], type_border BORDERTYPE)
 {
 	int lext = 0, rext = 0, uext = 0, dext = 0, bext = 0, fext = 0;
 	int dim = data.naxis();
@@ -54,7 +54,7 @@ void FiszTransform<DATATYPE>::dataExtension (to_array<DATATYPE, true> &data, int
 		lext = (newlen - len1) / 2; 
 		rext = (newlen - len1) - lext;
 		
-		to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen);
+		convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen);
 		for (int x=0; x<newlen; x++)
 			(*temp)(x) = data(x-lext, BORDERTYPE);
 		data = *temp;
@@ -72,7 +72,7 @@ void FiszTransform<DATATYPE>::dataExtension (to_array<DATATYPE, true> &data, int
 		lext = (newlen1 - len1) / 2; rext = (newlen1 - len1) - lext;
 		uext = (newlen2 - len2) / 2; dext = (newlen2 - len2) - uext;
 		
-		to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen1, newlen2);
+		convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen1, newlen2);
 		for (int y=0; y<newlen2; y++)
 			for (int x=0; x<newlen1; x++)
 				(*temp)(x, y) = data(x-lext, y-uext, BORDERTYPE);
@@ -92,7 +92,7 @@ void FiszTransform<DATATYPE>::dataExtension (to_array<DATATYPE, true> &data, int
 		uext = (newlen2 - len2) / 2; dext = (newlen2 - len2) - uext;
 		bext = (newlen3 - len3) / 2; fext = (newlen3 - len3) - fext;
 		
-		to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen1, newlen2, newlen3);
+		convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen1, newlen2, newlen3);
 		for (int z=0; z<newlen3; z++)
 			for (int y=0; y<newlen2; y++)
 				for (int x=0; x<newlen1; x++)
@@ -106,7 +106,7 @@ void FiszTransform<DATATYPE>::dataExtension (to_array<DATATYPE, true> &data, int
 }
 
 template<class DATATYPE>
-void FiszTransform<DATATYPE>::dataExtraction (to_array<DATATYPE, true> &data, int ext[])
+void FiszTransform<DATATYPE>::dataExtraction (convert_to_array<DATATYPE, true> &data, int ext[])
 {
 	int dim = data.naxis();
 	int lext = ext[0], rext = ext[1], uext = ext[2];
@@ -115,7 +115,7 @@ void FiszTransform<DATATYPE>::dataExtraction (to_array<DATATYPE, true> &data, in
 	if ((dim == 1) && ((lext != 0) || (rext != 0)))
 	{
 		int finallen = data.nx() - lext - rext;
-		to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen);
+		convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen);
 		for (int x=0; x<finallen; x++) (*tdata)(x) = data(lext+x);
 		data = (*tdata);
 		if (tdata != NULL) { delete tdata; tdata = NULL; }
@@ -125,7 +125,7 @@ void FiszTransform<DATATYPE>::dataExtraction (to_array<DATATYPE, true> &data, in
 	{
 		int finallen1 = data.nx() - lext - rext;
 		int finallen2 = data.ny() - uext - dext;
-		to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen1, finallen2);
+		convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen1, finallen2);
 		for (int x=0; x<finallen1; x++) 
 			for (int y=0; y<finallen2; y++)
 				(*tdata)(x, y) = data(lext+x, uext+y);
@@ -139,7 +139,7 @@ void FiszTransform<DATATYPE>::dataExtraction (to_array<DATATYPE, true> &data, in
 		int finallen1 = data.nx() - lext - rext;
 		int finallen2 = data.ny() - uext - dext;
 		int finallen3 = data.nz() - bext - fext;
-		to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen1, finallen2, finallen3);
+		convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen1, finallen2, finallen3);
 		for (int x=0; x<finallen1; x++) 
 		for (int y=0; y<finallen2; y++)
 		for (int z=0; z<finallen3; z++)	
@@ -150,14 +150,14 @@ void FiszTransform<DATATYPE>::dataExtraction (to_array<DATATYPE, true> &data, in
 }
 
 template<class DATATYPE>
-void FiszTransform<DATATYPE>::fisz1D (to_array<DATATYPE, true> &data)
+void FiszTransform<DATATYPE>::fisz1D (convert_to_array<DATATYPE, true> &data)
 {
     double ca, cd;
 	int len = data.nx();	
 	if (len <= 1) return;
 	else if (!is_power_of_2(len)) 
 		throw DataSizeException(len, "data size not of power of two");
-	to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(len);
+	convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(len);
 	
 	// decomposition by Haar transform and modification of detail coefficients
 	while (len > 1)
@@ -193,14 +193,14 @@ void FiszTransform<DATATYPE>::fisz1D (to_array<DATATYPE, true> &data)
 }
 
 template<class DATATYPE>
-void FiszTransform<DATATYPE>::ifisz1D (to_array<DATATYPE, true> &data)
+void FiszTransform<DATATYPE>::ifisz1D (convert_to_array<DATATYPE, true> &data)
 {
     double ca, cd;
 	int len = data.nx();
 	if (len <= 1) return;
 	else if (!is_power_of_2(len)) 
 		throw DataSizeException(len, "data size not of power of two");
-	to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(len);
+	convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(len);
 	
 	// decomposition by Haar transform
 	while (len > 1)
@@ -232,7 +232,7 @@ void FiszTransform<DATATYPE>::ifisz1D (to_array<DATATYPE, true> &data)
 }
 
 template<class DATATYPE>
-void FiszTransform<DATATYPE>::fisz2D (to_array<DATATYPE, true> &data)
+void FiszTransform<DATATYPE>::fisz2D (convert_to_array<DATATYPE, true> &data)
 {
 	double ca, dh, dv, dd;
 	int s, offsetx, offsety;
@@ -242,7 +242,7 @@ void FiszTransform<DATATYPE>::fisz2D (to_array<DATATYPE, true> &data)
 		throw DataSizeException(len1, "data size not of power of two");
 	else if (!is_power_of_2(len2))
 		throw DataSizeException(len2, "data size not of power of two");	
-	to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(len1, len2);
+	convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(len1, len2);
 	
 	// decomposition by Haar transform and modification of detail coefficients
 	while ((len1 > 1) && (len2 > 1))
@@ -318,7 +318,7 @@ void FiszTransform<DATATYPE>::fisz2D (to_array<DATATYPE, true> &data)
 }
 
 template<class DATATYPE>
-void FiszTransform<DATATYPE>::ifisz2D (to_array<DATATYPE, true> &data)
+void FiszTransform<DATATYPE>::ifisz2D (convert_to_array<DATATYPE, true> &data)
 {
 	double ca, dh, dv, dd;
 	int s, offsetx, offsety;
@@ -328,7 +328,7 @@ void FiszTransform<DATATYPE>::ifisz2D (to_array<DATATYPE, true> &data)
 		throw DataSizeException(len1, "data size not of power of two");
 	else if (!is_power_of_2(len2))
 		throw DataSizeException(len2, "data size not of power of two");
-	to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(len1, len2);
+	convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(len1, len2);
 	
 	// decomposition by Haar transform
 	while ((len1 > 1) && (len2 > 1))
@@ -396,7 +396,7 @@ void FiszTransform<DATATYPE>::ifisz2D (to_array<DATATYPE, true> &data)
 }
 
 template<class DATATYPE>
-void FiszTransform<DATATYPE>::fisz3D (to_array<DATATYPE, true> &data)
+void FiszTransform<DATATYPE>::fisz3D (convert_to_array<DATATYPE, true> &data)
 {
 	int len1 = data.nx(), len2 = data.ny(), len3 = data.nz();
 	int len = MIN(MIN(len1, len2), len3);
@@ -409,7 +409,7 @@ void FiszTransform<DATATYPE>::fisz3D (to_array<DATATYPE, true> &data)
 		throw DataSizeException(len3, "data size not of power of two");
 	
 	int s = iilog2(len);
-	to_array<DATATYPE, true> *coef = new to_array<DATATYPE, true>[7*s + 1];
+	convert_to_array<DATATYPE, true> *coef = new convert_to_array<DATATYPE, true>[7*s + 1];
 	
 	dblarray dfilterh(2), dfilterg(2), rfilterh(2), rfilterg(2);
 	dfilterh(0) = .5; dfilterh(1) = .5; dfilterg(0) = -.5; dfilterg(1) = .5;
@@ -449,7 +449,7 @@ void FiszTransform<DATATYPE>::fisz3D (to_array<DATATYPE, true> &data)
 }
 
 template<class DATATYPE>
-void FiszTransform<DATATYPE>::ifisz3D (to_array<DATATYPE, true> &data)
+void FiszTransform<DATATYPE>::ifisz3D (convert_to_array<DATATYPE, true> &data)
 {
 	int len1 = data.nx(), len2 = data.ny(), len3 = data.nz();
 	int len = MIN(MIN(len1, len2), len3);
@@ -462,7 +462,7 @@ void FiszTransform<DATATYPE>::ifisz3D (to_array<DATATYPE, true> &data)
 		throw DataSizeException(len3, "data size not of power of two");
 
 	int s = iilog2(len);
-	to_array<DATATYPE, true> *coef = new to_array<DATATYPE, true>[7*s + 1];
+	convert_to_array<DATATYPE, true> *coef = new convert_to_array<DATATYPE, true>[7*s + 1];
 	
 	dblarray dfilterh(2), dfilterg(2), rfilterh(2), rfilterg(2);
 	dfilterh(0) = .5; dfilterh(1) = .5; dfilterg(0) = -.5; dfilterg(1) = .5;

--- a/src/mwir/libmwir/ImLib_mwir.h
+++ b/src/mwir/libmwir/ImLib_mwir.h
@@ -20,25 +20,25 @@ class Utils
 
  public:
   // median value of the absolute value of a given data set
-  static DATATYPE absMedian (to_array<DATATYPE, true> &data);
+  static DATATYPE absMedian (convert_to_array<DATATYPE, true> &data);
   // critical threshold for standard normal distribution, tailProba <= 0.5
   static double criticalThreshGauss (double tailProba);
   // cumulative of the normal distribution
   static double cumNormal (double x);
   // Anscombe transform of a data set
-  static void anscombeTransform (to_array<DATATYPE, true> &data);
-  static void invAnscombeTransform (to_array<DATATYPE, true> &data);
+  static void anscombeTransform (convert_to_array<DATATYPE, true> &data);
+  static void invAnscombeTransform (convert_to_array<DATATYPE, true> &data);
 
   // generate Donoho's clipped block 1D signal
-  static void blockSignal (int len, double scaling, to_array<DATATYPE, true> &signal1D);
+  static void blockSignal (int len, double scaling, convert_to_array<DATATYPE, true> &signal1D);
   // generate a 1D signal with a Gaussian form
-  static void regularSignal (int cx, double sigma, double peakIntense, double backIntense, to_array<DATATYPE, true> &signal1D);
+  static void regularSignal (int cx, double sigma, double peakIntense, double backIntense, convert_to_array<DATATYPE, true> &signal1D);
   // generate a 3D signal with a regional evalutionary Gaussian form
   static void regularSignal (int cx, int cy, double sigma0, double sigma1, double k, \
-			     double peakIntense, double backIntense, to_array<DATATYPE, true> &signal3D, double flow[]);
+			     double peakIntense, double backIntense, convert_to_array<DATATYPE, true> &signal3D, double flow[]);
 
   // calculate the source flow of a Gaussian form signal
-  static void gaussianSourceFlow (to_array<DATATYPE, true> &signal3D, double cx, double cy, \
+  static void gaussianSourceFlow (convert_to_array<DATATYPE, true> &signal3D, double cx, double cy, \
 				  double sigma0, double sigma1, double k, double backIntense, double flow[]);
 
   // mean of a vector
@@ -46,9 +46,9 @@ class Utils
   // standard deviation of a vector
   static double std (DATATYPE vec[], int len);
   // Normalized Integrated Square Error where the noise is Poissonian
-  static double NISE (to_array<DATATYPE, true> &orig, to_array<DATATYPE, true> &estim);
+  static double NISE (convert_to_array<DATATYPE, true> &orig, convert_to_array<DATATYPE, true> &estim);
   // Integrated Square Error where the noise has a spatially stable variance
-  static double ISE (to_array<DATATYPE, true> &orig, to_array<DATATYPE, true> &estim);
+  static double ISE (convert_to_array<DATATYPE, true> &orig, convert_to_array<DATATYPE, true> &estim);
 
   // return the combinatorial number C(n, k)
   static double Cnk (int n, int k);
@@ -62,7 +62,7 @@ class Utils
   // ndet  record for each pixel, the number of detection among NExp experiences
   // ndlen is the length of the array ndet
   // NITER is max. number of iteration
-  static void EMMixBinomialParam (double &alpha, double &pa, double &pi, int NExp, to_array<DATATYPE, true> ndet[], int ndlen, int NITER);
+  static void EMMixBinomialParam (double &alpha, double &pa, double &pi, int NExp, convert_to_array<DATATYPE, true> ndet[], int ndlen, int NITER);
 //  // ROC area where [alpha0, alpha1] is the valid H0 portion interval
 //  static double rocArea (int len, double alpha[], double pa[], double pi[], double alpha0, double alpha1);
   // ROC area
@@ -70,7 +70,7 @@ class Utils
 };
 
 template <class DATATYPE> 
-DATATYPE Utils<DATATYPE>::absMedian (to_array<DATATYPE, true> &data)
+DATATYPE Utils<DATATYPE>::absMedian (convert_to_array<DATATYPE, true> &data)
 {
 	DATATYPE medv;
 	int less, greater, equal;
@@ -140,7 +140,7 @@ double Utils<DATATYPE>::cumNormal (double x)
 }
 
 template <class DATATYPE> 
-void Utils<DATATYPE>::anscombeTransform (to_array<DATATYPE, true> &data)
+void Utils<DATATYPE>::anscombeTransform (convert_to_array<DATATYPE, true> &data)
 {
   int nlen = data.n_elem();
   for (int i=0; i<nlen; i++)
@@ -148,7 +148,7 @@ void Utils<DATATYPE>::anscombeTransform (to_array<DATATYPE, true> &data)
 }
 
 template <class DATATYPE> 
-void Utils<DATATYPE>::invAnscombeTransform (to_array<DATATYPE, true> &data)
+void Utils<DATATYPE>::invAnscombeTransform (convert_to_array<DATATYPE, true> &data)
 {
   int nlen = data.n_elem();
   for (int i=0; i<nlen; i++)
@@ -156,7 +156,7 @@ void Utils<DATATYPE>::invAnscombeTransform (to_array<DATATYPE, true> &data)
 }
 
 template <class DATATYPE> 
-void Utils<DATATYPE>::blockSignal (int len, double scaling, to_array<DATATYPE, true> &signal1D)
+void Utils<DATATYPE>::blockSignal (int len, double scaling, convert_to_array<DATATYPE, true> &signal1D)
 {
   signal1D.resize(len);
 
@@ -174,7 +174,7 @@ void Utils<DATATYPE>::blockSignal (int len, double scaling, to_array<DATATYPE, t
 }
 
 template <class DATATYPE>
-void Utils<DATATYPE>::regularSignal (int cx, double sigma, double peakIntense, double backIntense, to_array<DATATYPE, true> &signal1D)
+void Utils<DATATYPE>::regularSignal (int cx, double sigma, double peakIntense, double backIntense, convert_to_array<DATATYPE, true> &signal1D)
 {
   int nx = signal1D.nx();
   double sig = 2. * sigma * sigma;
@@ -185,7 +185,7 @@ void Utils<DATATYPE>::regularSignal (int cx, double sigma, double peakIntense, d
 
 template <class DATATYPE> 
 void Utils<DATATYPE>::regularSignal (int cx, int cy, double sigma0, double sigma1, double k, \
-				     double peakIntense, double backIntense, to_array<DATATYPE, true> &signal3D, double flow[])
+				     double peakIntense, double backIntense, convert_to_array<DATATYPE, true> &signal3D, double flow[])
 {
   int nx = signal3D.nx(), ny = signal3D.ny(), nz = signal3D.nz();
   double dsig = (sigma1 - sigma0) / (nz - 1), sig = sigma0;
@@ -215,7 +215,7 @@ void Utils<DATATYPE>::regularSignal (int cx, int cy, double sigma0, double sigma
 }
 
 template <class DATATYPE>
-void Utils<DATATYPE>::gaussianSourceFlow (to_array<DATATYPE, true> &signal3D, double cx, double cy, \
+void Utils<DATATYPE>::gaussianSourceFlow (convert_to_array<DATATYPE, true> &signal3D, double cx, double cy, \
 					  double sigma0, double sigma1, double k, double backIntense, double flow[])
 {
   int nx = signal3D.nx(), ny = signal3D.ny(), nz = signal3D.nz();
@@ -258,7 +258,7 @@ double Utils<DATATYPE>::std (DATATYPE vec[], int len)
 }
 
 template <class DATATYPE> 
-double Utils<DATATYPE>::NISE (to_array<DATATYPE, true> &orig, to_array<DATATYPE, true> &estim)
+double Utils<DATATYPE>::NISE (convert_to_array<DATATYPE, true> &orig, convert_to_array<DATATYPE, true> &estim)
 {
   int dlen = orig.n_elem();
   double sum = 0., lambda, temp;
@@ -274,7 +274,7 @@ double Utils<DATATYPE>::NISE (to_array<DATATYPE, true> &orig, to_array<DATATYPE,
 }
 
 template <class DATATYPE> 
-double Utils<DATATYPE>::ISE (to_array<DATATYPE, true> &orig, to_array<DATATYPE, true> &estim)
+double Utils<DATATYPE>::ISE (convert_to_array<DATATYPE, true> &orig, convert_to_array<DATATYPE, true> &estim)
 {
   int dlen = orig.n_elem();
   double sum = 0., temp;
@@ -321,7 +321,7 @@ double Utils<DATATYPE>::binomial (int n, int k, double p)
 }
 
 template <class DATATYPE> 
-void Utils<DATATYPE>::EMMixBinomialParam (double &alpha, double &pa, double &pi, int NExp, to_array<DATATYPE, true> ndet[], int ndlen, int NITER)
+void Utils<DATATYPE>::EMMixBinomialParam (double &alpha, double &pa, double &pi, int NExp, convert_to_array<DATATYPE, true> ndet[], int ndlen, int NITER)
 {
   long N = 0;
   int k;

--- a/src/mwir/libmwir/Wavelet_wmir.h
+++ b/src/mwir/libmwir/Wavelet_wmir.h
@@ -64,17 +64,17 @@ class OrthogonalWaveletTransform
 		// (I)DWT 1D along a certain axis
 		// only used by (I)DWT3D
 		// axis = 0, 1, 2 : X, Y, Z
-		static void transformXYZ (to_array<DATATYPE, true> &data, dblarray &dfilterh, dblarray &dfilterg, to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int axis, type_border BORDERTYPE);
-		static void reconstructionXYZ (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, dblarray &rfilterh, dblarray &rfilterg, to_array<DATATYPE, true> &data, int axis);
+		static void transformXYZ (convert_to_array<DATATYPE, true> &data, dblarray &dfilterh, dblarray &dfilterg, convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int axis, type_border BORDERTYPE);
+		static void reconstructionXYZ (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, dblarray &rfilterh, dblarray &rfilterg, convert_to_array<DATATYPE, true> &data, int axis);
 		
 	public:
 		// orthogonal wavelet types
 		static const int HAAR=0, DAUB4=4, SYML4=16;
 		
 		// resize the data to the same size of the reference
-		static void resizeData (to_array<DATATYPE, true> &data, to_array<DATATYPE, true> &ref, type_border BORDERTYPE=I_ZERO);
+		static void resizeData (convert_to_array<DATATYPE, true> &data, convert_to_array<DATATYPE, true> &ref, type_border BORDERTYPE=I_ZERO);
 		// resize the data to [nx], [nx, ny] or [nx, ny, nz] according to the dimension of the data
-		static void resizeData (to_array<DATATYPE, true> &data, int nx, int ny, int nz, type_border BORDERTYPE=I_ZERO);
+		static void resizeData (convert_to_array<DATATYPE, true> &data, int nx, int ny, int nz, type_border BORDERTYPE=I_ZERO);
 		
 		// get the decomposition filters, i.e. \bar{h}, \bar{g}
 		// where h is considered to start from the origin
@@ -83,88 +83,88 @@ class OrthogonalWaveletTransform
 		static void getWaveletReconsFilter (int filterName, dblarray &rfilterh, dblarray &rfilterg);
 		
 		// DWT 1D
-		static void dwt1D (to_array<DATATYPE, true> &data, \
+		static void dwt1D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE=I_MIRROR);
-		static void dwt1D (to_array<DATATYPE, true> &data, \
+		static void dwt1D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE=I_MIRROR);
 		
 		// IDWT 1D 
-		static void idwt1D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+		static void idwt1D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data);
-		static void idwt1D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &data);
+		static void idwt1D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			int filterName, \
-			to_array<DATATYPE, true> &data);			
+			convert_to_array<DATATYPE, true> &data);			
 
 		// DWT 2D
-		static void dwt2D (to_array<DATATYPE, true> &data, \
+		static void dwt2D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE=I_MIRROR);
-		static void dwt2D (to_array<DATATYPE, true> &data, \
+		static void dwt2D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE=I_MIRROR);
 					
 		// IDWT 2D 
-		static void idwt2D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+		static void idwt2D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data);
-		static void idwt2D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &data);
+		static void idwt2D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			int filterName, \
-			to_array<DATATYPE, true> &data);
+			convert_to_array<DATATYPE, true> &data);
 
 		// DWT 3D
-		static void dwt3D (to_array<DATATYPE, true> &data, \
+		static void dwt3D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			type_border BORDERTYPE=I_MIRROR);
-		static void dwt3D (to_array<DATATYPE, true> &data, \
+		static void dwt3D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			type_border BORDERTYPE=I_MIRROR);
 					
 		// IDWT 3D 
 		static void idwt3D ( \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data);
+			convert_to_array<DATATYPE, true> &data);
 		static void idwt3D ( \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			int filterName, \
-			to_array<DATATYPE, true> &data);
+			convert_to_array<DATATYPE, true> &data);
 };
 
 template <class DATATYPE>
@@ -177,19 +177,19 @@ template <class DATATYPE>
 const int OrthogonalWaveletTransform<DATATYPE>::SYML4;
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::resizeData(to_array<DATATYPE, true> &data, to_array<DATATYPE, true> &ref, type_border BORDERTYPE)
+void OrthogonalWaveletTransform<DATATYPE>::resizeData(convert_to_array<DATATYPE, true> &data, convert_to_array<DATATYPE, true> &ref, type_border BORDERTYPE)
 {
 	resizeData(data, ref.nx(), ref.ny(), ref.nz(), BORDERTYPE);
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::resizeData(to_array<DATATYPE, true> &data, int nx, int ny, int nz, type_border BORDERTYPE)
+void OrthogonalWaveletTransform<DATATYPE>::resizeData(convert_to_array<DATATYPE, true> &data, int nx, int ny, int nz, type_border BORDERTYPE)
 {
 	int dnx = data.nx(), dny = data.ny(), dnz = data.nz();
 	if ((nx == dnx) && (ny == dny) && (nz == dnz)) return;
 	int dim = data.naxis();
 
-	to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(dnx, dny, dnz);
+	convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(dnx, dny, dnz);
 	*temp = data;
 	if (dim == 1)
 	{
@@ -272,9 +272,9 @@ void OrthogonalWaveletTransform<DATATYPE>::getWaveletReconsFilter (int filterNam
 }
 
 template <class DATATYPE>
-void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true> &data, dblarray &dfilterh, dblarray &dfilterg, to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int axis, type_border BORDERTYPE)
+void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (convert_to_array<DATATYPE, true> &data, dblarray &dfilterh, dblarray &dfilterg, convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int axis, type_border BORDERTYPE)
 {
-	to_array<DATATYPE, true> *line = NULL, *linea = NULL, *lined = NULL;
+	convert_to_array<DATATYPE, true> *line = NULL, *linea = NULL, *lined = NULL;
 	int lenx, leny, lenz, dlenx, dleny, dlenz;
 	
 	if (axis == 0)
@@ -283,9 +283,9 @@ void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true
 		dlenx = getDecompResultLength(lenx, dfilterh.n_elem());
 		ca.resize(dlenx, leny, lenz);
 		cd.resize(dlenx, leny, lenz);
-		line = new to_array<DATATYPE, true>(lenx);
-		linea = new to_array<DATATYPE, true>(dlenx);
-		lined = new to_array<DATATYPE, true>(dlenx);
+		line = new convert_to_array<DATATYPE, true>(lenx);
+		linea = new convert_to_array<DATATYPE, true>(dlenx);
+		lined = new convert_to_array<DATATYPE, true>(dlenx);
 		
 		for (int z=0; z<lenz; z++)
 		for (int y=0; y<leny; y++)
@@ -306,9 +306,9 @@ void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true
 		dleny = getDecompResultLength(leny, dfilterh.n_elem());
 		ca.resize(lenx, dleny, lenz);
 		cd.resize(lenx, dleny, lenz);
-		line = new to_array<DATATYPE, true>(leny);
-		linea = new to_array<DATATYPE, true>(dleny);
-		lined = new to_array<DATATYPE, true>(dleny);
+		line = new convert_to_array<DATATYPE, true>(leny);
+		linea = new convert_to_array<DATATYPE, true>(dleny);
+		lined = new convert_to_array<DATATYPE, true>(dleny);
 
 		for (int z=0; z<lenz; z++)
 		for (int x=0; x<lenx; x++)
@@ -329,9 +329,9 @@ void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true
 		dlenz = getDecompResultLength(lenz, dfilterh.n_elem());	
 		ca.resize(lenx, leny, dlenz);
 		cd.resize(lenx, leny, dlenz);
-		line = new to_array<DATATYPE, true>(lenz);
-		linea = new to_array<DATATYPE, true>(dlenz);
-		lined = new to_array<DATATYPE, true>(dlenz);
+		line = new convert_to_array<DATATYPE, true>(lenz);
+		linea = new convert_to_array<DATATYPE, true>(dlenz);
+		lined = new convert_to_array<DATATYPE, true>(dlenz);
 
 		for (int y=0; y<leny; y++)
 		for (int x=0; x<lenx; x++)
@@ -354,18 +354,18 @@ void OrthogonalWaveletTransform<DATATYPE>::transformXYZ (to_array<DATATYPE, true
 }
 
 template <class DATATYPE>
-void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, dblarray &rfilterh, dblarray &rfilterg, to_array<DATATYPE, true> &data, int axis)
+void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, dblarray &rfilterh, dblarray &rfilterg, convert_to_array<DATATYPE, true> &data, int axis)
 {
-	to_array<DATATYPE, true> *line = NULL, *linea = NULL, *lined = NULL;
+	convert_to_array<DATATYPE, true> *line = NULL, *linea = NULL, *lined = NULL;
 	int lenx, leny, lenz, rlenx, rleny, rlenz;
 	
 	if (axis == 0)
 	{
 		lenx = ca.nx(); leny = ca.ny(); lenz = ca.nz();
 		rlenx = getReconsResultLength(lenx, rfilterh.n_elem());
-		line = new to_array<DATATYPE, true>(rlenx);
-		linea = new to_array<DATATYPE, true>(lenx);
-		lined = new to_array<DATATYPE, true>(lenx);
+		line = new convert_to_array<DATATYPE, true>(rlenx);
+		linea = new convert_to_array<DATATYPE, true>(lenx);
+		lined = new convert_to_array<DATATYPE, true>(lenx);
 		data.resize(rlenx, leny, lenz);
 		
 		for (int z=0; z<lenz; z++)
@@ -385,9 +385,9 @@ void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (to_array<DATATYPE,
 	{
 		lenx = ca.nx(); leny = ca.ny(); lenz = ca.nz();
 		rleny = getReconsResultLength(leny, rfilterh.n_elem());
-		line = new to_array<DATATYPE, true>(rleny);
-		linea = new to_array<DATATYPE, true>(leny);
-		lined = new to_array<DATATYPE, true>(leny);
+		line = new convert_to_array<DATATYPE, true>(rleny);
+		linea = new convert_to_array<DATATYPE, true>(leny);
+		lined = new convert_to_array<DATATYPE, true>(leny);
 		data.resize(lenx, rleny, lenz);
 		
 		for (int z=0; z<lenz; z++)
@@ -407,9 +407,9 @@ void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (to_array<DATATYPE,
 	{
 		lenx = ca.nx(); leny = ca.ny(); lenz = ca.nz();
 		rlenz = getReconsResultLength(lenz, rfilterh.n_elem());
-		line = new to_array<DATATYPE, true>(rlenz);
-		linea = new to_array<DATATYPE, true>(lenz);
-		lined = new to_array<DATATYPE, true>(lenz);
+		line = new convert_to_array<DATATYPE, true>(rlenz);
+		linea = new convert_to_array<DATATYPE, true>(lenz);
+		lined = new convert_to_array<DATATYPE, true>(lenz);
 		data.resize(lenx, leny, rlenz);
 		
 		for (int y=0; y<leny; y++)
@@ -433,9 +433,9 @@ void OrthogonalWaveletTransform<DATATYPE>::reconstructionXYZ (to_array<DATATYPE,
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::dwt1D (to_array<DATATYPE, true> &data, \
+void OrthogonalWaveletTransform<DATATYPE>::dwt1D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE)
 {
 	int datalen = data.nx();
@@ -465,9 +465,9 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt1D (to_array<DATATYPE, true> &data
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::dwt1D (to_array<DATATYPE, true> &data, \
+void OrthogonalWaveletTransform<DATATYPE>::dwt1D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE)
 {
 	dblarray filterh, filterg;
@@ -476,9 +476,9 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt1D (to_array<DATATYPE, true> &data
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::idwt1D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+void OrthogonalWaveletTransform<DATATYPE>::idwt1D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	int calen = ca.nx(), cdlen = cd.nx();
 	if (calen != cdlen)
@@ -511,9 +511,9 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt1D (to_array<DATATYPE, true> &ca,
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::idwt1D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, \
+void OrthogonalWaveletTransform<DATATYPE>::idwt1D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, \
 			int filterName, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	dblarray filterh, filterg;
 	getWaveletReconsFilter(filterName, filterh, filterg);
@@ -521,9 +521,9 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt1D (to_array<DATATYPE, true> &ca,
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data, \
+void OrthogonalWaveletTransform<DATATYPE>::dwt2D (convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE)
 {
 	int datalenx = data.nx(), dataleny = data.ny();
@@ -535,11 +535,11 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data
 	ca.resize(reslenx, resleny); 	ch.resize(reslenx, resleny);
 	cv.resize(reslenx, resleny); 	cd.resize(reslenx, resleny);
 
-	to_array<DATATYPE, true> *temph = new to_array<DATATYPE, true>(reslenx, dataleny);
-	to_array<DATATYPE, true> *tempg = new to_array<DATATYPE, true>(reslenx, dataleny);
-	to_array<DATATYPE, true> *line = new to_array<DATATYPE, true>(datalenx);
-	to_array<DATATYPE, true> *atempline = new to_array<DATATYPE, true>(reslenx);
-	to_array<DATATYPE, true> *dtempline = new to_array<DATATYPE, true>(reslenx);
+	convert_to_array<DATATYPE, true> *temph = new convert_to_array<DATATYPE, true>(reslenx, dataleny);
+	convert_to_array<DATATYPE, true> *tempg = new convert_to_array<DATATYPE, true>(reslenx, dataleny);
+	convert_to_array<DATATYPE, true> *line = new convert_to_array<DATATYPE, true>(datalenx);
+	convert_to_array<DATATYPE, true> *atempline = new convert_to_array<DATATYPE, true>(reslenx);
+	convert_to_array<DATATYPE, true> *dtempline = new convert_to_array<DATATYPE, true>(reslenx);
 	for (int y=0; y<dataleny; y++)
 	{
 		for (int x=0; x<datalenx; x++) (*line)(x) = data(x,y);
@@ -554,10 +554,10 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data
 	if (atempline != NULL) { delete atempline; atempline = NULL; }
 	if (dtempline != NULL) { delete dtempline; dtempline = NULL; }
 	
-	to_array<DATATYPE, true> *col1 = new to_array<DATATYPE, true>(dataleny);
-	to_array<DATATYPE, true> *col2 = new to_array<DATATYPE, true>(dataleny);
-	to_array<DATATYPE, true> *atempcol = new to_array<DATATYPE, true>(resleny);
-	to_array<DATATYPE, true> *dtempcol = new to_array<DATATYPE, true>(resleny);
+	convert_to_array<DATATYPE, true> *col1 = new convert_to_array<DATATYPE, true>(dataleny);
+	convert_to_array<DATATYPE, true> *col2 = new convert_to_array<DATATYPE, true>(dataleny);
+	convert_to_array<DATATYPE, true> *atempcol = new convert_to_array<DATATYPE, true>(resleny);
+	convert_to_array<DATATYPE, true> *dtempcol = new convert_to_array<DATATYPE, true>(resleny);
 	for (int x=0; x<reslenx; x++)
 	{
 		for (int y=0; y<dataleny; y++)
@@ -587,9 +587,9 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data, \
+void OrthogonalWaveletTransform<DATATYPE>::dwt2D (convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+			convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			type_border BORDERTYPE)
 {
 	dblarray filterh, filterg;
@@ -598,9 +598,9 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt2D (to_array<DATATYPE, true> &data
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+void OrthogonalWaveletTransform<DATATYPE>::idwt2D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	int calenx = ca.nx(), caleny = ca.ny();
 	int chlenx = ch.nx(), chleny = ch.ny();
@@ -617,14 +617,14 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca,
 	int resleny = getReconsResultLength(caleny, hlen);
 	data.resize(reslenx, resleny);
 
-	to_array<DATATYPE, true> *temph = new to_array<DATATYPE, true>(calenx, resleny);
-	to_array<DATATYPE, true> *tempg = new to_array<DATATYPE, true>(calenx, resleny);
-	to_array<DATATYPE, true> *cola = new to_array<DATATYPE, true>(caleny);
-	to_array<DATATYPE, true> *colh = new to_array<DATATYPE, true>(chleny);
-	to_array<DATATYPE, true> *colv = new to_array<DATATYPE, true>(cvleny);
-	to_array<DATATYPE, true> *cold = new to_array<DATATYPE, true>(cdleny);
-	to_array<DATATYPE, true> *coltemph = new to_array<DATATYPE, true>(resleny);	
-	to_array<DATATYPE, true> *coltempg = new to_array<DATATYPE, true>(resleny);	
+	convert_to_array<DATATYPE, true> *temph = new convert_to_array<DATATYPE, true>(calenx, resleny);
+	convert_to_array<DATATYPE, true> *tempg = new convert_to_array<DATATYPE, true>(calenx, resleny);
+	convert_to_array<DATATYPE, true> *cola = new convert_to_array<DATATYPE, true>(caleny);
+	convert_to_array<DATATYPE, true> *colh = new convert_to_array<DATATYPE, true>(chleny);
+	convert_to_array<DATATYPE, true> *colv = new convert_to_array<DATATYPE, true>(cvleny);
+	convert_to_array<DATATYPE, true> *cold = new convert_to_array<DATATYPE, true>(cdleny);
+	convert_to_array<DATATYPE, true> *coltemph = new convert_to_array<DATATYPE, true>(resleny);	
+	convert_to_array<DATATYPE, true> *coltempg = new convert_to_array<DATATYPE, true>(resleny);	
 	for (int x=0; x<calenx; x++)
 	{
 		for (int y=0; y<caleny; y++)
@@ -649,9 +649,9 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca,
 	if (coltemph != NULL) { delete coltemph; coltemph = NULL; }
 	if (coltempg != NULL) { delete coltempg; coltempg = NULL; }
 	
-	to_array<DATATYPE, true> *lineh = new to_array<DATATYPE, true>(calenx);	
-	to_array<DATATYPE, true> *lineg = new to_array<DATATYPE, true>(calenx);	
-	to_array<DATATYPE, true> *line = new to_array<DATATYPE, true>(reslenx);	
+	convert_to_array<DATATYPE, true> *lineh = new convert_to_array<DATATYPE, true>(calenx);	
+	convert_to_array<DATATYPE, true> *lineg = new convert_to_array<DATATYPE, true>(calenx);	
+	convert_to_array<DATATYPE, true> *line = new convert_to_array<DATATYPE, true>(reslenx);	
 	for (int y=0; y<resleny; y++)
 	{
 		for (int x=0; x<calenx; x++)
@@ -671,9 +671,9 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca,
 }
 
 template <class DATATYPE> 
-void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &ch, to_array<DATATYPE, true> &cv, to_array<DATATYPE, true> &cd, \
+void OrthogonalWaveletTransform<DATATYPE>::idwt2D (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &ch, convert_to_array<DATATYPE, true> &cv, convert_to_array<DATATYPE, true> &cd, \
 			int filterName, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	dblarray filterh, filterg;
 	getWaveletReconsFilter(filterName, filterh, filterg);
@@ -682,16 +682,16 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt2D (to_array<DATATYPE, true> &ca,
 
 template <class DATATYPE>
 void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
-			to_array<DATATYPE, true> &data, \
+			convert_to_array<DATATYPE, true> &data, \
 			dblarray &dfilterh, dblarray &dfilterg, \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			type_border BORDERTYPE)
 {
 	int hlen = dfilterh.n_elem(), glen = dfilterg.n_elem();
@@ -707,18 +707,18 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
 	cggh.resize(reslenx, resleny, reslenz); cggg.resize(reslenx, resleny, reslenz);
 
 	// X
-	to_array<DATATYPE, true> *temph = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temph = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempg = new convert_to_array<DATATYPE, true>;
 	transformXYZ(data, dfilterh, dfilterg, *temph, *tempg, 0, BORDERTYPE);
 	
 	// Y
-	to_array<DATATYPE, true> *temphh = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *temphg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temphh = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temphg = new convert_to_array<DATATYPE, true>;
 	transformXYZ(*temph, dfilterh, dfilterg, *temphh, *temphg, 1, BORDERTYPE);
 	if (temph != NULL) { delete temph; temph = NULL; }
 	
-	to_array<DATATYPE, true> *tempgh = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempgg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempgh = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempgg = new convert_to_array<DATATYPE, true>;
 	transformXYZ(*tempg, dfilterh, dfilterg, *tempgh, *tempgg, 1, BORDERTYPE);
 	if (tempg != NULL) { delete tempg; tempg = NULL; }
 	
@@ -736,16 +736,16 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
 
 template <class DATATYPE>
 void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
-			to_array<DATATYPE, true> &data, \
+			convert_to_array<DATATYPE, true> &data, \
 			int filterName, \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			type_border BORDERTYPE)
 {
 	dblarray filterh, filterg;
@@ -755,16 +755,16 @@ void OrthogonalWaveletTransform<DATATYPE>::dwt3D ( \
 
 template <class DATATYPE>
 void OrthogonalWaveletTransform<DATATYPE>::idwt3D ( \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			dblarray &rfilterh, dblarray &rfilterg, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	int hlen = rfilterh.n_elem(), glen = rfilterg.n_elem();
 	if (hlen != glen)
@@ -791,18 +791,18 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt3D ( \
 	data.resize(reslenx, resleny, reslenz);
 	
 	// Z
-	to_array<DATATYPE, true> *temphh = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *temphg = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempgh = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempgg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temphh = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temphg = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempgh = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempgg = new convert_to_array<DATATYPE, true>;
 	reconstructionXYZ(ca, chhg, rfilterh, rfilterg, *temphh, 2);
 	reconstructionXYZ(chgh, chgg, rfilterh, rfilterg, *temphg, 2);
 	reconstructionXYZ(cghh, cghg, rfilterh, rfilterg, *tempgh, 2);
 	reconstructionXYZ(cggh, cggg, rfilterh, rfilterg, *tempgg, 2);
 	
 	// Y
-	to_array<DATATYPE, true> *temph = new to_array<DATATYPE, true>;
-	to_array<DATATYPE, true> *tempg = new to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *temph = new convert_to_array<DATATYPE, true>;
+	convert_to_array<DATATYPE, true> *tempg = new convert_to_array<DATATYPE, true>;
 	reconstructionXYZ(*temphh, *temphg, rfilterh, rfilterg, *temph, 1);
 	if (temphh != NULL) { delete temphh; temphh = NULL; }
 	if (temphg != NULL) { delete temphg; temphg = NULL; }
@@ -819,16 +819,16 @@ void OrthogonalWaveletTransform<DATATYPE>::idwt3D ( \
 
 template <class DATATYPE>
 void OrthogonalWaveletTransform<DATATYPE>::idwt3D ( \
-			to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &chhg, \
-			to_array<DATATYPE, true> &chgh, \
-			to_array<DATATYPE, true> &chgg, \
-			to_array<DATATYPE, true> &cghh, \
-			to_array<DATATYPE, true> &cghg, \
-			to_array<DATATYPE, true> &cggh, \
-			to_array<DATATYPE, true> &cggg, \
+			convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &chhg, \
+			convert_to_array<DATATYPE, true> &chgh, \
+			convert_to_array<DATATYPE, true> &chgg, \
+			convert_to_array<DATATYPE, true> &cghh, \
+			convert_to_array<DATATYPE, true> &cghg, \
+			convert_to_array<DATATYPE, true> &cggh, \
+			convert_to_array<DATATYPE, true> &cggg, \
 			int filterName, \
-			to_array<DATATYPE, true> &data)
+			convert_to_array<DATATYPE, true> &data)
 {
 	dblarray filterh, filterg;
 	getWaveletReconsFilter(filterName, filterh, filterg);
@@ -894,7 +894,7 @@ class WaveletShrinkage
 	public:
 		// gaussian noise standard deviation MAD estimation 
 		// sigma = median (abs(waveletdata)) / 0.6745 
-		double gaussianStdDevEstim (to_array<DATATYPE, true> &waveletData);
+		double gaussianStdDevEstim (convert_to_array<DATATYPE, true> &waveletData);
 
 		// Denoise gaussian noise 
 		// Hard threshold = k * sigma; sup use -sigma / sigma (>=0) to indicate the insignificant/significant coef. region 
@@ -902,8 +902,8 @@ class WaveletShrinkage
 		// alpha is the preset p-value of the significance level when DEFAULT is not set
 		// DEFAULT indicates to use the universal threshold
 		// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double gaussHardThreshold (to_array<DATATYPE, true> &waveletData, int scale[], \
-			double alpha, double sigma, to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
+		double gaussHardThreshold (convert_to_array<DATATYPE, true> &waveletData, int scale[], \
+			double alpha, double sigma, convert_to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
 
 		// Denoise gaussian noise 
 		// Soft threshold = k * sigma; sup use -sigma / sigma (>=0) to indicate the insignificant/significant coef. region 
@@ -911,15 +911,15 @@ class WaveletShrinkage
 		// alpha is the preset p-value of the significance level when DEFAULT is not set
 		// DEFAULT indicates to use the universal threshold
 		// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double gaussSoftThreshold (to_array<DATATYPE, true> &waveletData, int scale[], \
-			double alpha, double sigma, to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
+		double gaussSoftThreshold (convert_to_array<DATATYPE, true> &waveletData, int scale[], \
+			double alpha, double sigma, convert_to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
 
 		// Denoise gaussian noise 
 		// FDR threshold; sup use -sigma / sigma (>=0) to indicate the insignificant/significant coef. region
 		// alpha is the preset FDR
       	// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double gaussFDRThreshold (to_array<DATATYPE, true> &waveletData, \
-			double sigma, double alpha, bool indep = true, to_array<SUPTYPE, true> *sup = NULL);
+		double gaussFDRThreshold (convert_to_array<DATATYPE, true> &waveletData, \
+			double sigma, double alpha, bool indep = true, convert_to_array<SUPTYPE, true> *sup = NULL);
 
 		// Direct Haar hard threshold in using Kolaczyk's approximation for Poisson noise
 		// The transform data is assumed to use L1-normalized Haar filter,
@@ -929,7 +929,7 @@ class WaveletShrinkage
 		// alpha is the preset p-value of the significance level when DEFAULT is not set
 		// DEFAULT indicates to use the universal threshold
 		// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double haarKolaThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int scale[], double alpha, to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
+		double haarKolaThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
 
 		// Direct Haar hard threshold in using modified Kolaczyk's approximation (Fisher approx.) for Poisson noise
 		// The transform data is assumed to use L1-normalized Haar filter,
@@ -939,7 +939,7 @@ class WaveletShrinkage
 		// alpha is the preset p-value of the significance level when DEFAULT is not set
 		// DEFAULT indicates to use the universal threshold
 		// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double haarMKolaThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int scale[], double alpha, to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
+		double haarMKolaThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup = NULL, int N = 1, bool DEFAULT = false);
 
 		// Direct Haar hard threshold based on Bijaoui-Jammal's thresholding table for Poisson noise
 		// The transform data is assumed to use L1-normalized Haar filter,
@@ -947,7 +947,7 @@ class WaveletShrinkage
 		// scale[] is the scale along each direction
 		// alpha is the preset p-value of the significance level
 		// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double haarBJThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int scale[], double alpha, to_array<SUPTYPE, true> *sup = NULL); 
+		double haarBJThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup = NULL); 
 
 		// Direct Haar hard threshold based on FDR (false discovery rate) for Poisson noise
 		// for a band
@@ -956,7 +956,7 @@ class WaveletShrinkage
 		// scale[] is the scale along each direction
 		// alpha is the preset FDR
 		// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double haarFDRThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int scale[], double alpha, bool indep = true, to_array<SUPTYPE, true> *sup = NULL);
+		double haarFDRThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, bool indep = true, convert_to_array<SUPTYPE, true> *sup = NULL);
 
 		// Direct Haar hard threshold based on FDR (false discovery rate) for Poisson noise
 		// for the bands of a scale
@@ -965,7 +965,7 @@ class WaveletShrinkage
 		// scale[] is the scale along each direction
 		// alpha is the preset FDR
 		// the thresholding p-value (of the distr. of the absolute value of the coef.) is returned 
-		double haarFDRThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> cd[], int len, int scale[], double alpha, bool indep = true, to_array<SUPTYPE, true> *sup = NULL);
+		double haarFDRThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> cd[], int len, int scale[], double alpha, bool indep = true, convert_to_array<SUPTYPE, true> *sup = NULL);
 
 		// Model (prior) based Haar coef. threshold for Poisson noise
 		// The transform data is assumed to use L1-normalized Haar filter,
@@ -978,9 +978,9 @@ class WaveletShrinkage
 		// N is the length of the original data
 		// DEFAULT indicates to use the universal threshold
 		// the thresholding p-value is returned 
-		double haarModelThreshold (to_array<DATATYPE, true> &caModel, \
-               to_array<DATATYPE, true> &cdModel, to_array<DATATYPE, true> &cd, \
-               int scale[], double alpha, to_array<SUPTYPE, true> *sup = NULL, \
+		double haarModelThreshold (convert_to_array<DATATYPE, true> &caModel, \
+               convert_to_array<DATATYPE, true> &cdModel, convert_to_array<DATATYPE, true> &cd, \
+               int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup = NULL, \
                int N = 1, bool DEFAULT = false);
                
 		// Model (prior) based Haar coef. FDR threshold for Poisson noise
@@ -992,13 +992,13 @@ class WaveletShrinkage
 		// scale[] is the scale along each direction
 		// alpha is the preset FDR
 		// the thresholding p-value is returned 
-        double haarModelFDRThreshold (to_array<DATATYPE, true> &caModel, \
-               to_array<DATATYPE, true> &cdModel, to_array<DATATYPE, true> &cd, \
-               int scale[], double alpha, bool indep = true, to_array<SUPTYPE, true> *sup = NULL);               
+        double haarModelFDRThreshold (convert_to_array<DATATYPE, true> &caModel, \
+               convert_to_array<DATATYPE, true> &cdModel, convert_to_array<DATATYPE, true> &cd, \
+               int scale[], double alpha, bool indep = true, convert_to_array<SUPTYPE, true> *sup = NULL);               
 };
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussianStdDevEstim (to_array<DATATYPE, true> &waveletData)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussianStdDevEstim (convert_to_array<DATATYPE, true> &waveletData)
 {
 	double med = Utils<DATATYPE>::absMedian(waveletData);
 	
@@ -1006,7 +1006,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussianStdDevEstim (to_array<DATATY
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussHardThreshold (to_array<DATATYPE, true> &waveletData, int scale[], double alpha, double sigma, to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussHardThreshold (convert_to_array<DATATYPE, true> &waveletData, int scale[], double alpha, double sigma, convert_to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
 {
     int dim = waveletData.naxis();
 	int nx = waveletData.nx(), ny = waveletData.ny(), nz = waveletData.nz();
@@ -1071,7 +1071,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussHardThreshold (to_array<DATATYP
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussSoftThreshold (to_array<DATATYPE, true> &waveletData, int scale[], double alpha, double sigma, to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussSoftThreshold (convert_to_array<DATATYPE, true> &waveletData, int scale[], double alpha, double sigma, convert_to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
 {
     int dim = waveletData.naxis();
 	int nx = waveletData.nx(), ny = waveletData.ny(), nz = waveletData.nz();
@@ -1149,8 +1149,8 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussSoftThreshold (to_array<DATATYP
 	return (DEFAULT ? (2.*(1-Utils<double>::cumNormal(cthresh))) : alpha);
 }
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE, true> &waveletData, \
-					  double sigma, double alpha, bool indep, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (convert_to_array<DATATYPE, true> &waveletData, \
+					  double sigma, double alpha, bool indep, convert_to_array<SUPTYPE, true> *sup)
 {
   int dim = waveletData.naxis();
   int nx = waveletData.nx(), ny = waveletData.ny(), nz = waveletData.nz();
@@ -1159,7 +1159,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE
   if (dim == 1)
     {
       if (sup != NULL) sup->resize(nx);
-      to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx);
+      convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx);
       for (int x=0; x<nx; x++)
 	  {
 	  if (sigma < 1e-20) (*pvals)(x) = 0;
@@ -1189,7 +1189,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE
   else if (dim == 2)
     {
       if (sup != NULL) sup->resize(nx, ny);
-      to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny);
+      convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny);
       for (int x=0; x<nx; x++)
       for (int y=0; y<ny; y++)
 	  {
@@ -1221,7 +1221,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE
   else if (dim == 3)
     {
       if (sup != NULL) sup->resize(nx, ny, nz);
-      to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny, nz);
+      convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny, nz);
       for (int x=0; x<nx; x++)
       for (int y=0; y<ny; y++)
       for (int z=0; z<nz; z++)
@@ -1258,7 +1258,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::gaussFDRThreshold (to_array<DATATYPE
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::haarKolaThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int scale[], double alpha, to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::haarKolaThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
 {
 	int nx, ny, nz;
 	double coeff, lambda, thresh, zalpha2;
@@ -1348,8 +1348,8 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarKolaThreshold (to_array<DATATYPE
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::haarMKolaThreshold (to_array<DATATYPE, true> &ca, \
-			to_array<DATATYPE, true> &cd, int scale[], double alpha, to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::haarMKolaThreshold (convert_to_array<DATATYPE, true> &ca, \
+			convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup, int N, bool DEFAULT)
 {
 	int nx, ny, nz, rn;
 	double coeff, pcoef[5], pm[4], pmi[4], lambda, thresh, zalpha2;
@@ -1473,7 +1473,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarMKolaThreshold (to_array<DATATYP
 }
 
 template <class DATATYPE, class SUPTYPE> 
-double WaveletShrinkage<DATATYPE, SUPTYPE>::haarBJThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int scale[], double alpha, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::haarBJThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup)
 {
 	int nx, ny, nz;
 	double coeff, lambda, thresh, alpha2 = alpha / 2.;
@@ -1558,7 +1558,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarBJThreshold (to_array<DATATYPE, 
 }
 
 template <class DATATYPE, class SUPTYPE>
-double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> &cd, int scale[], double alpha, bool indep, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> &cd, int scale[], double alpha, bool indep, convert_to_array<SUPTYPE, true> *sup)
 {
 	int nx, ny, nz;
 	double coeff, lambda, fdrp;
@@ -1573,7 +1573,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 	{
 		nx = cd.nx();
 		if (sup != NULL) sup->resize(nx);
-	        to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx);
+	        convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx);
 		for (int x=0; x<nx; x++)
 		{
 			lambda = MAX(0, ca(x)); lambdaj = lambdajparam * lambda;
@@ -1608,7 +1608,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 	{
 	        nx = cd.nx(); ny = cd.ny();
 		if (sup != NULL) sup->resize(nx, ny);
-	        to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny);
+	        convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny);
 		for (int x=0; x<nx; x++)
 		for (int y=0; y<ny; y++)
 		{
@@ -1646,7 +1646,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 	{
   	        nx = cd.nx(); ny = cd.ny(); nz = cd.nz();
 		if (sup != NULL) sup->resize(nx, ny, nz);
-	        to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny, nz);
+	        convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny, nz);
 		for (int x=0; x<nx; x++)
 		for (int y=0; y<ny; y++)
 		for (int z=0; z<nz; z++)
@@ -1688,7 +1688,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 }
 
 template <class DATATYPE, class SUPTYPE>
-double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE, true> &ca, to_array<DATATYPE, true> cd[], int len, int scale[], double alpha, bool indep, to_array<SUPTYPE, true> *sup)
+double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (convert_to_array<DATATYPE, true> &ca, convert_to_array<DATATYPE, true> cd[], int len, int scale[], double alpha, bool indep, convert_to_array<SUPTYPE, true> *sup)
 {
 	int nx, ny, nz;
 	double coeff, lambda, fdrp;
@@ -1703,7 +1703,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 	{
 	    nx = cd[0].nx();
 	    if (sup != NULL) for (int l=0; l<len; l++) sup[l].resize(nx);
-	    to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(len, nx);
+	    convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(len, nx);
 		for (int l=0; l<len; l++)
 		for (int x=0; x<nx; x++)
 		{
@@ -1741,7 +1741,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 	{
 	    nx = cd[0].nx(); ny = cd[0].ny();
 		if (sup != NULL) for (int l=0; l<len; l++) sup[l].resize(nx, ny);
-	    to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(len, nx, ny);
+	    convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(len, nx, ny);
 		for (int l=0; l<len; l++)
 		for (int x=0; x<nx; x++)
 		for (int y=0; y<ny; y++)
@@ -1781,7 +1781,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 	{
   	    nx = cd[0].nx(); ny = cd[0].ny(); nz = cd[0].nz();
 		if (sup != NULL) for (int l=0; l<len; l++) sup[l].resize(nx, ny, nz);
-	    to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(len*nx, ny, nz);
+	    convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(len*nx, ny, nz);
 		for (int l=0; l<len; l++)
 		for (int x=0; x<nx; x++)
 		for (int y=0; y<ny; y++)
@@ -1825,9 +1825,9 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarFDRThreshold (to_array<DATATYPE,
 }
 
 template <class DATATYPE, class SUPTYPE>
-double WaveletShrinkage<DATATYPE, SUPTYPE>::haarModelThreshold (to_array<DATATYPE, true> &caModel, \
-               to_array<DATATYPE, true> &cdModel, to_array<DATATYPE, true> &cd, \
-               int scale[], double alpha, to_array<SUPTYPE, true> *sup, \
+double WaveletShrinkage<DATATYPE, SUPTYPE>::haarModelThreshold (convert_to_array<DATATYPE, true> &caModel, \
+               convert_to_array<DATATYPE, true> &cdModel, convert_to_array<DATATYPE, true> &cd, \
+               int scale[], double alpha, convert_to_array<SUPTYPE, true> *sup, \
                int N, bool DEFAULT)
 {
 	int nx, ny, nz;
@@ -1915,9 +1915,9 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarModelThreshold (to_array<DATATYP
 
 template <class DATATYPE, class SUPTYPE>
 double WaveletShrinkage<DATATYPE, SUPTYPE>::haarModelFDRThreshold \
-       (to_array<DATATYPE, true> &caModel, \
-        to_array<DATATYPE, true> &cdModel, to_array<DATATYPE, true> &cd, \
-        int scale[], double alpha, bool indep, to_array<SUPTYPE, true> *sup)
+       (convert_to_array<DATATYPE, true> &caModel, \
+        convert_to_array<DATATYPE, true> &cdModel, convert_to_array<DATATYPE, true> &cd, \
+        int scale[], double alpha, bool indep, convert_to_array<SUPTYPE, true> *sup)
 {
 	int nx, ny, nz;
 	double coefobs, lambda1, lambda2, p, fdrp;
@@ -1931,7 +1931,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarModelFDRThreshold \
 	{
 		nx = cd.nx();
 		if (sup != NULL) sup->resize(nx);
-	    to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx);
+	    convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx);
 		for (int x=0; x<nx; x++)
 		{
             coefobs = cd(x);
@@ -1966,7 +1966,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarModelFDRThreshold \
 	{
 	    nx = cd.nx(); ny = cd.ny();
 		if (sup != NULL) sup->resize(nx, ny);
-	    to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny);
+	    convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny);
 		for (int x=0; x<nx; x++)
 		for (int y=0; y<ny; y++)
 		{
@@ -2003,7 +2003,7 @@ double WaveletShrinkage<DATATYPE, SUPTYPE>::haarModelFDRThreshold \
 	{
   	    nx = cd.nx(); ny = cd.ny(); nz = cd.nz();
 		if (sup != NULL) sup->resize(nx, ny, nz);
-	    to_array<DATATYPE, true> *pvals = new to_array<DATATYPE, true>(nx, ny, nz);
+	    convert_to_array<DATATYPE, true> *pvals = new convert_to_array<DATATYPE, true>(nx, ny, nz);
 		for (int x=0; x<nx; x++)
 		for (int y=0; y<ny; y++)
 		for (int z=0; z<nz; z++)

--- a/src/mwir/mwirmain/anscfisz.cc
+++ b/src/mwir/mwirmain/anscfisz.cc
@@ -254,7 +254,7 @@ int scaleOfData (int dim, int nx, int ny, int nz)
 
 // display the content of a data array (useful in debug mode)
 template <typename DATATYPE>
-void display (to_array<DATATYPE, true> &data)
+void display (convert_to_array<DATATYPE, true> &data)
 {
 	int dim = data.naxis();
 	if (VERBOSE)
@@ -347,7 +347,7 @@ void cycleTrans (fltarray &data, int dx, int dy, int dz)
 }
 
 template <typename DATATYPE>
-void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, double cst)
+void setConst (convert_to_array<DATATYPE, true> &dest, convert_to_array<DATATYPE, true> &ref, double cst)
 {
 	int nx = ref.nx(), ny = ref.ny(), nz = ref.nz();
 	int len = ref.n_elem();
@@ -359,7 +359,7 @@ void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, do
 
 // Wavelet denoising - general process
 template <typename SUPTYPE>
-void b3SplineDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup)
+void b3SplineDenoise (fltarray &data, convert_to_array<SUPTYPE, true> *multiSup)
 {
 	int dim = data.naxis();
 	double pr, fdrp; // threshold p-value and FDR-threshold p-value
@@ -424,7 +424,7 @@ void b3SplineDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup)
 
 // for different modes of iteration
 template <typename SUPTYPE>
-void procArr (fltarray &origdata, fltarray &data, to_array<SUPTYPE, true> &coef, double lambda)
+void procArr (fltarray &origdata, fltarray &data, convert_to_array<SUPTYPE, true> &coef, double lambda)
 {
   int n = data.n_elem();
 
@@ -510,7 +510,7 @@ void multiSupIter (fltarray &origdata, fltarray &solution, fltarray *multiSup, i
 
 // Anscombe denoising
 template <typename SUPTYPE>
-void anscombeDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup=NULL)
+void anscombeDenoise (fltarray &data, convert_to_array<SUPTYPE, true> *multiSup=NULL)
 {
   // Anscombe transform
   if (VERBOSE)

--- a/src/mwir/mwirmain/bihaar_gaussian_filter.cc
+++ b/src/mwir/mwirmain/bihaar_gaussian_filter.cc
@@ -283,7 +283,7 @@ int scaleOfData (int dim, int nx, int ny, int nz)
 
 // display the content of a data array (useful in debug mode)
 template <typename DATATYPE>
-void display (to_array<DATATYPE, true> &data)
+void display (convert_to_array<DATATYPE, true> &data)
 {
 	int dim = data.naxis();
 	if (VERBOSE)
@@ -326,7 +326,7 @@ void display (to_array<DATATYPE, true> &data)
 // maxlen is the max. length of the filters
 // this function garantees the even number of samples along each direction when decimated transform is used.
 template <typename DATATYPE>
-void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYPE, int scale, bool dec[], int ext[6])
+void extData(convert_to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYPE, int scale, bool dec[], int ext[6])
 {
   int nx = data.nx(), ny = data.ny(), nz = data.nz();
   int dim = data.naxis();
@@ -359,7 +359,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
     {
       int newlen = nx + lext + rext;
       if ((newlen % 2 != 0) && dec[0]) { newlen++; ext[1]++; rext++; }
-      to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen);
+      convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen);
 
       for (int x=0; x<newlen; x++)
 	(*temp)(x) = data(x-lext, BORDERTYPE);
@@ -372,7 +372,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
       if ((newlen1 % 2 != 0) && dec[0]) { newlen1++; ext[1]++; rext++; }
       if ((newlen2 % 2 != 0) && dec[1]) { newlen2++; ext[3]++; dext++; }
 
-      to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen1, newlen2);
+      convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen1, newlen2);
       for (int y=0; y<newlen2; y++)
 	for (int x=0; x<newlen1; x++)
 	  (*temp)(x, y) = data(x-lext, y-uext, BORDERTYPE);
@@ -386,7 +386,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
       if ((newlen2 % 2 != 0) && dec[1]) { newlen2++; ext[3]++; dext++; }
       if ((newlen3 % 2 != 0) && dec[2]) { newlen3++; ext[5]++; fext++; }
       
-      to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen1, newlen2, newlen3);
+      convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen1, newlen2, newlen3);
       for (int z=0; z<newlen3; z++)
 	for (int y=0; y<newlen2; y++)
 	  for (int x=0; x<newlen1; x++)
@@ -398,7 +398,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
 
 // extract the data from the extension version
 template <typename DATATYPE>
-void extractData (to_array<DATATYPE, true> &data, int ext[6])
+void extractData (convert_to_array<DATATYPE, true> &data, int ext[6])
 {
   int dim = data.naxis();
   int lext = ext[0], rext = ext[1], uext = ext[2];
@@ -407,7 +407,7 @@ void extractData (to_array<DATATYPE, true> &data, int ext[6])
   if ((dim == 1) && ((lext != 0) || (rext != 0)))
     {
       int finallen = data.nx() - lext - rext;
-      to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen);
+      convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen);
       for (int x=0; x<finallen; x++) (*tdata)(x) = data(lext+x);
       data = (*tdata);
       delete tdata; tdata = NULL;
@@ -417,7 +417,7 @@ void extractData (to_array<DATATYPE, true> &data, int ext[6])
     {
       int finallen1 = data.nx() - lext - rext;
       int finallen2 = data.ny() - uext - dext;
-      to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen1, finallen2);
+      convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen1, finallen2);
       for (int x=0; x<finallen1; x++) 
 	for (int y=0; y<finallen2; y++)
 	  (*tdata)(x, y) = data(lext+x, uext+y);
@@ -431,7 +431,7 @@ void extractData (to_array<DATATYPE, true> &data, int ext[6])
       int finallen1 = data.nx() - lext - rext;
       int finallen2 = data.ny() - uext - dext;
       int finallen3 = data.nz() - bext - fext;
-      to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen1, finallen2, finallen3);
+      convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen1, finallen2, finallen3);
       for (int x=0; x<finallen1; x++) 
 	for (int y=0; y<finallen2; y++)
 	  for (int z=0; z<finallen3; z++)	
@@ -442,7 +442,7 @@ void extractData (to_array<DATATYPE, true> &data, int ext[6])
 }
 
 template <typename DATATYPE>
-void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, double cst)
+void setConst (convert_to_array<DATATYPE, true> &dest, convert_to_array<DATATYPE, true> &ref, double cst)
 {
 	int dim = ref.naxis();
 	int nx = ref.nx(), ny = ref.ny(), nz = ref.nz();
@@ -518,7 +518,7 @@ double noiseEstimation (fltarray &data)
 
 // Wavelet denoising - general process
 template <typename SUPTYPE>
-void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], to_array<SUPTYPE, true> *multiSup = NULL)
+void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], convert_to_array<SUPTYPE, true> *multiSup = NULL)
 {
 	int dim = data.naxis();
 	int ext[NSCALE][6];
@@ -820,7 +820,7 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], to_array<S
 }
 
 template <typename SUPTYPE>
-void procArr (fltarray &origdata, fltarray &data, to_array<SUPTYPE, true> &coef, double lambda)
+void procArr (fltarray &origdata, fltarray &data, convert_to_array<SUPTYPE, true> &coef, double lambda)
 {
   int dim = data.naxis();
   int nx = data.nx(), ny = data.ny(), nz = data.nz();

--- a/src/mwir/mwirmain/bihaar_gaussian_filter_2d1d.cc
+++ b/src/mwir/mwirmain/bihaar_gaussian_filter_2d1d.cc
@@ -289,7 +289,7 @@ int scaleOfData (int dim, int nx, int ny, int nz)
 
 // display the content of a data array (useful in debug mode)
 template <typename DATATYPE>
-void display (to_array<DATATYPE, true> &data)
+void display (convert_to_array<DATATYPE, true> &data)
 {
   if (VERBOSE)
     {
@@ -313,7 +313,7 @@ void display (to_array<DATATYPE, true> &data)
 // maxlen is the max. length of the filters
 // this function garantees the even number of samples along each direction when decimated transform is used.
 template <typename DATATYPE>
-void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYPE, int scale, bool dec[], int ext[6])
+void extData(convert_to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYPE, int scale, bool dec[], int ext[6])
 {
   int nx = data.nx(), ny = data.ny(), nz = data.nz();
   int dim = 3;
@@ -343,7 +343,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
   if ((newlen2 % 2 != 0) && dec[1]) { newlen2++; ext[3]++; dext++; }
   if ((newlen3 % 2 != 0) && dec[2]) { newlen3++; ext[5]++; fext++; }
       
-  to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen1, newlen2, newlen3);
+  convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen1, newlen2, newlen3);
   for (int z=0; z<newlen3; z++)
     for (int y=0; y<newlen2; y++)
       for (int x=0; x<newlen1; x++)
@@ -354,7 +354,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
 
 // extract the data from the extension version
 template <typename DATATYPE>
-void extractData (to_array<DATATYPE, true> &data, int ext[6])
+void extractData (convert_to_array<DATATYPE, true> &data, int ext[6])
 {
   int lext = ext[0], rext = ext[1], uext = ext[2];
   int dext = ext[3], bext = ext[4], fext = ext[5];
@@ -364,7 +364,7 @@ void extractData (to_array<DATATYPE, true> &data, int ext[6])
       int finallen1 = data.nx() - lext - rext;
       int finallen2 = data.ny() - uext - dext;
       int finallen3 = data.nz() - bext - fext;
-      to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen1, finallen2, finallen3);
+      convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen1, finallen2, finallen3);
       for (int x=0; x<finallen1; x++) 
 	for (int y=0; y<finallen2; y++)
 	  for (int z=0; z<finallen3; z++)	
@@ -375,7 +375,7 @@ void extractData (to_array<DATATYPE, true> &data, int ext[6])
 }
 
 template <typename DATATYPE>
-void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, double cst)
+void setConst (convert_to_array<DATATYPE, true> &dest, convert_to_array<DATATYPE, true> &ref, double cst)
 {
 	int dim = ref.naxis();
 	int nx = ref.nx(), ny = ref.ny(), nz = ref.nz();
@@ -451,7 +451,7 @@ double noiseEstimation (fltarray &data)
 
 // Wavelet denoising - general process
 template <typename SUPTYPE>
-void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], to_array<SUPTYPE, true> *multiSup = NULL)
+void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], convert_to_array<SUPTYPE, true> *multiSup = NULL)
 {
 	int extxy[NSCALEXY][6];
 	int extz[NSCALEZ][6];
@@ -700,7 +700,7 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], to_array<S
 }
 
 template <typename SUPTYPE>
-void procArr (fltarray &origdata, fltarray &data, to_array<SUPTYPE, true> &coef, double lambda)
+void procArr (fltarray &origdata, fltarray &data, convert_to_array<SUPTYPE, true> &coef, double lambda)
 {
   int nx = data.nx(), ny = data.ny(), nz = data.nz();
 

--- a/src/mwir/mwirmain/bihaar_poisson_filter.cc
+++ b/src/mwir/mwirmain/bihaar_poisson_filter.cc
@@ -364,7 +364,7 @@ int scaleOfData (int dim, int nx, int ny, int nz)
 
 // display the content of a data array (useful in debug mode)
 template <typename DATATYPE>
-void display (to_array<DATATYPE, true> &data)
+void display (convert_to_array<DATATYPE, true> &data)
 {
 	int dim = data.naxis();
 	if (VERBOSE)
@@ -404,7 +404,7 @@ void display (to_array<DATATYPE, true> &data)
 }
 
 template <typename DATATYPE>
-void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, double cst)
+void setConst (convert_to_array<DATATYPE, true> &dest, convert_to_array<DATATYPE, true> &ref, double cst)
 {
 	int dim = ref.naxis();
 	int nx = ref.nx(), ny = ref.ny(), nz = ref.nz();
@@ -434,7 +434,7 @@ void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, do
 // maxlen is the max. length of the filters
 // this function garantees the even number of samples along each direction when decimated transform is used.
 template <typename DATATYPE>
-void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYPE, int scale, bool dec[], int ext[6])
+void extData(convert_to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYPE, int scale, bool dec[], int ext[6])
 {
   int nx = data.nx(), ny = data.ny(), nz = data.nz();
   int dim = data.naxis();
@@ -468,7 +468,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
     {
       int newlen = nx + lext + rext;
       if ((newlen % 2 != 0) && dec[0]) { newlen++; ext[1]++; rext++; }
-      to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen);
+      convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen);
 
       for (int x=0; x<newlen; x++)
 	  (*temp)(x) = data(x-lext, BORDERTYPE);
@@ -481,7 +481,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
       if ((newlen1 % 2 != 0) && dec[0]) { newlen1++; ext[1]++; rext++; }
       if ((newlen2 % 2 != 0) && dec[1]) { newlen2++; ext[3]++; dext++; }
 
-      to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen1, newlen2);
+      convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen1, newlen2);
       for (int y=0; y<newlen2; y++)
 	for (int x=0; x<newlen1; x++)
 	  (*temp)(x, y) = data(x-lext, y-uext, BORDERTYPE);
@@ -495,7 +495,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
       if ((newlen2 % 2 != 0) && dec[1]) { newlen2++; ext[3]++; dext++; }
       if ((newlen3 % 2 != 0) && dec[2]) { newlen3++; ext[5]++; fext++; }
       
-      to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen1, newlen2, newlen3);
+      convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen1, newlen2, newlen3);
       for (int z=0; z<newlen3; z++)
 	for (int y=0; y<newlen2; y++)
 	  for (int x=0; x<newlen1; x++)
@@ -507,7 +507,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
 
 // extract the data from the extension version
 template <typename DATATYPE>
-void extractData (to_array<DATATYPE, true> &data, int ext[6])
+void extractData (convert_to_array<DATATYPE, true> &data, int ext[6])
 {
   int dim = data.naxis();
   int lext = ext[0], rext = ext[1], uext = ext[2];
@@ -516,7 +516,7 @@ void extractData (to_array<DATATYPE, true> &data, int ext[6])
   if ((dim == 1) && ((lext != 0) || (rext != 0)))
     {
       int finallen = data.nx() - lext - rext;
-      to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen);
+      convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen);
       for (int x=0; x<finallen; x++) (*tdata)(x) = data(lext+x);
       data = (*tdata);
       delete tdata; tdata = NULL;
@@ -526,7 +526,7 @@ void extractData (to_array<DATATYPE, true> &data, int ext[6])
     {
       int finallen1 = data.nx() - lext - rext;
       int finallen2 = data.ny() - uext - dext;
-      to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen1, finallen2);
+      convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen1, finallen2);
       for (int x=0; x<finallen1; x++) 
 	for (int y=0; y<finallen2; y++)
 	  (*tdata)(x, y) = data(lext+x, uext+y);
@@ -540,7 +540,7 @@ void extractData (to_array<DATATYPE, true> &data, int ext[6])
       int finallen1 = data.nx() - lext - rext;
       int finallen2 = data.ny() - uext - dext;
       int finallen3 = data.nz() - bext - fext;
-      to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen1, finallen2, finallen3);
+      convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen1, finallen2, finallen3);
       for (int x=0; x<finallen1; x++) 
 	  for (int y=0; y<finallen2; y++)
 	  for (int z=0; z<finallen3; z++)	
@@ -606,7 +606,7 @@ void cycleTrans (fltarray &data, int dx, int dy, int dz)
 // Wavelet denoising - general process
 template <typename SUPTYPE>
 void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
-		             to_array<SUPTYPE, true> *multiSup = NULL, fltarray *model = NULL)
+		             convert_to_array<SUPTYPE, true> *multiSup = NULL, fltarray *model = NULL)
 {
 	int dim = data.naxis();
 	int ext[NSCALE][6];
@@ -1397,7 +1397,7 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 
 // for different modes of iteration
 template <typename SUPTYPE>
-void procArr (fltarray &origdata, fltarray &data, to_array<SUPTYPE, true> &coef, double lambda)
+void procArr (fltarray &origdata, fltarray &data, convert_to_array<SUPTYPE, true> &coef, double lambda)
 {
   int dim = data.naxis();
   int nx = data.nx(), ny = data.ny(), nz = data.nz();

--- a/src/mwir/mwirmain/bihaar_poisson_filter_2d1d.cc
+++ b/src/mwir/mwirmain/bihaar_poisson_filter_2d1d.cc
@@ -346,7 +346,7 @@ int scaleOfData (int dim, int nx, int ny, int nz)
 
 // display the content of a data array (useful in debug mode)
 template <typename DATATYPE>
-void display (to_array<DATATYPE, true> &data)
+void display (convert_to_array<DATATYPE, true> &data)
 {
   if (VERBOSE)
     {
@@ -367,7 +367,7 @@ void display (to_array<DATATYPE, true> &data)
 }
 
 template <typename DATATYPE>
-void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, double cst)
+void setConst (convert_to_array<DATATYPE, true> &dest, convert_to_array<DATATYPE, true> &ref, double cst)
 {
 	int nx = ref.nx(), ny = ref.ny(), nz = ref.nz();
 	dest.resize(nx, ny, nz);
@@ -382,7 +382,7 @@ void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, do
 // maxlen is the max. length of the filters
 // this function garantees the even number of samples along each direction when decimated transform is used.
 template <typename DATATYPE>
-void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYPE, int scale, bool dec[], int ext[6])
+void extData(convert_to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYPE, int scale, bool dec[], int ext[6])
 {
   int nx = data.nx(), ny = data.ny(), nz = data.nz();
   int dim = 3;
@@ -418,7 +418,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
   if ((newlen2 % 2 != 0) && dec[1]) { newlen2++; ext[3]++; dext++; }
   if ((newlen3 % 2 != 0) && dec[2]) { newlen3++; ext[5]++; fext++; }
       
-  to_array<DATATYPE, true> *temp = new to_array<DATATYPE, true>(newlen1, newlen2, newlen3);
+  convert_to_array<DATATYPE, true> *temp = new convert_to_array<DATATYPE, true>(newlen1, newlen2, newlen3);
   for (int z=0; z<newlen3; z++)
     for (int y=0; y<newlen2; y++)
       for (int x=0; x<newlen1; x++)
@@ -429,7 +429,7 @@ void extData(to_array<DATATYPE, true> &data, int maxlen[], type_border BORDERTYP
 
 // extract the data from the extension version
 template <typename DATATYPE>
-void extractData (to_array<DATATYPE, true> &data, int ext[6])
+void extractData (convert_to_array<DATATYPE, true> &data, int ext[6])
 {
   int lext = ext[0], rext = ext[1], uext = ext[2];
   int dext = ext[3], bext = ext[4], fext = ext[5];
@@ -439,7 +439,7 @@ void extractData (to_array<DATATYPE, true> &data, int ext[6])
       int finallen1 = data.nx() - lext - rext;
       int finallen2 = data.ny() - uext - dext;
       int finallen3 = data.nz() - bext - fext;
-      to_array<DATATYPE,true> *tdata = new to_array<DATATYPE, true>(finallen1, finallen2, finallen3);
+      convert_to_array<DATATYPE,true> *tdata = new convert_to_array<DATATYPE, true>(finallen1, finallen2, finallen3);
       for (int x=0; x<finallen1; x++) 
 	for (int y=0; y<finallen2; y++)
 	  for (int z=0; z<finallen3; z++)	
@@ -477,7 +477,7 @@ void cycleTrans (fltarray &data, int dx, int dy, int dz)
 // Wavelet denoising - general process
 template <typename SUPTYPE>
 void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
-                     to_array<SUPTYPE, true> *multiSup = NULL, fltarray *model = NULL)
+                     convert_to_array<SUPTYPE, true> *multiSup = NULL, fltarray *model = NULL)
 {
 	int extxy[NSCALEXY][6];
 	int extz[NSCALEZ][6];
@@ -1030,7 +1030,7 @@ void waveletDenoise (fltarray &data, SubBandFilter sbf[], bool dec[], \
 
 // for different modes of iteration in BHAAR case
 template <typename SUPTYPE>
-void procArr (fltarray &origdata, fltarray &data, to_array<SUPTYPE, true> &coef, double lambda)
+void procArr (fltarray &origdata, fltarray &data, convert_to_array<SUPTYPE, true> &coef, double lambda)
 {
   int nx = data.nx(), ny = data.ny(), nz = data.nz();
 

--- a/src/mwir/mwirmain/msvst_iwt2d_coupled_nobias.cc_pbcompil
+++ b/src/mwir/mwirmain/msvst_iwt2d_coupled_nobias.cc_pbcompil
@@ -257,7 +257,7 @@ int scaleOfData (int dim, int nx, int ny, int nz)
 
 // display the content of a data array (useful in debug mode)
 template <typename DATATYPE>
-void display (to_array<DATATYPE, true> &data)
+void display (convert_to_array<DATATYPE, true> &data)
 {
 	int dim = data.naxis();
 	if (VERBOSE)
@@ -297,7 +297,7 @@ void display (to_array<DATATYPE, true> &data)
 }
 
 template <typename DATATYPE>
-void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, double cst)
+void setConst (convert_to_array<DATATYPE, true> &dest, convert_to_array<DATATYPE, true> &ref, double cst)
 {
 	int nx = ref.nx(), ny = ref.ny(), nz = ref.nz();
 	int len = ref.n_elem();
@@ -309,7 +309,7 @@ void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, do
 
 // Wavelet denoising - general process
 template <typename SUPTYPE>
-void b3SplineDenoise (fltarray &data, fltarray *model, to_array<SUPTYPE, true> *multiSup)
+void b3SplineDenoise (fltarray &data, fltarray *model, convert_to_array<SUPTYPE, true> *multiSup)
 {
 	int dim = data.naxis();
 	double pr, fdrp; // threshold p-value and FDR-threshold p-value
@@ -387,7 +387,7 @@ void b3SplineDenoise (fltarray &data, fltarray *model, to_array<SUPTYPE, true> *
 
 // for different modes of iteration
 template <typename SUPTYPE>
-void procArr (fltarray &origdata, fltarray &data, to_array<SUPTYPE, true> &coef, double lambda)
+void procArr (fltarray &origdata, fltarray &data, convert_to_array<SUPTYPE, true> &coef, double lambda)
 {
   int n = data.n_elem();
 
@@ -415,7 +415,7 @@ void procArr (fltarray &data, double lambda)
 }
 
 template <typename SUPTYPE>
-void procArr (fltarray &origdata, fltarray &data, to_array<SUPTYPE, true> &coef)
+void procArr (fltarray &origdata, fltarray &data, convert_to_array<SUPTYPE, true> &coef)
 {
   int n = data.n_elem();
 

--- a/src/mwir/mwirmain/msvst_iwt2d_coupled_nobias_perline..cc_pbcompil
+++ b/src/mwir/mwirmain/msvst_iwt2d_coupled_nobias_perline..cc_pbcompil
@@ -244,7 +244,7 @@ int scaleOfData (int dim, int nx, int ny, int nz)
 
 // display the content of a data array (useful in debug mode)
 template <typename DATATYPE>
-void display (to_array<DATATYPE, true> &data)
+void display (convert_to_array<DATATYPE, true> &data)
 {
 	int dim = data.naxis();
 	if (VERBOSE)
@@ -284,7 +284,7 @@ void display (to_array<DATATYPE, true> &data)
 }
 
 template <typename DATATYPE>
-void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, double cst)
+void setConst (convert_to_array<DATATYPE, true> &dest, convert_to_array<DATATYPE, true> &ref, double cst)
 {
 	int nx = ref.nx(), ny = ref.ny(), nz = ref.nz();
 	int len = ref.n_elem();
@@ -296,7 +296,7 @@ void setConst (to_array<DATATYPE, true> &dest, to_array<DATATYPE, true> &ref, do
 
 // Wavelet denoising - general process
 template <typename SUPTYPE>
-void b3SplineDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup)
+void b3SplineDenoise (fltarray &data, convert_to_array<SUPTYPE, true> *multiSup)
 {
 	int dim = data.naxis();
 	double pr, fdrp; // threshold p-value and FDR-threshold p-value
@@ -399,7 +399,7 @@ void b3SplineDenoise (fltarray &data, to_array<SUPTYPE, true> *multiSup)
 
 // for different modes of iteration
 template <typename SUPTYPE>
-void procArr (fltarray &origdata, fltarray &data, to_array<SUPTYPE, true> &coef, double lambda)
+void procArr (fltarray &origdata, fltarray &data, convert_to_array<SUPTYPE, true> &coef, double lambda)
 {
   int n = data.n_elem();
 
@@ -427,7 +427,7 @@ void procArr (fltarray &data, double lambda)
 }
 
 template <typename SUPTYPE>
-void procArr (fltarray &origdata, fltarray &data, to_array<SUPTYPE, true> &coef)
+void procArr (fltarray &origdata, fltarray &data, convert_to_array<SUPTYPE, true> &coef)
 {
   int n = data.n_elem();
 

--- a/src/sparse/libtools/TempArray.h
+++ b/src/sparse/libtools/TempArray.h
@@ -87,6 +87,7 @@ public:
   convert_to_array (int pi_Nx, int pi_Ny, const char *Name);
   convert_to_array (int pi_Nx, int pi_Ny, int pi_Nz, const char *Name);
   convert_to_array (int pi_Nx, int pi_Ny=0, int pi_Nz=0);
+  convert_to_array(const convert_to_array<PARAM_TYPE, ARRAY_TYPE>& pro_Obj);
   ~convert_to_array ();
   void free();
   PARAM_TYPE* buffer();
@@ -163,8 +164,6 @@ public:
   double mean () const;
   void sigma_clip (float& pf_Mean, float& pf_Sigma, int pi_Nit=3) const;
   float sigma_clip (int pi_Nit=3) const;
-
-  convert_to_array<PARAM_TYPE,ARRAY_TYPE> (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Obj);
 
   inline void setBorder( type_border border )
   {

--- a/src/sparse/libtools/TempArray.h
+++ b/src/sparse/libtools/TempArray.h
@@ -1,7 +1,6 @@
 #ifndef _TEMPARRAY_H
 #define _TEMPARRAY_H
 
-
 #include <iostream>
 #include <string>
 #include <cmath>
@@ -40,18 +39,18 @@ public:
 
 typedef unsigned char cbyte;
 
-#define fltarray to_array<float,true>
-#define dblarray to_array<double,true>
-#define intarray to_array<int,true>
-#define bytearray to_array<cbyte,true>
-#define cfarray to_array<complex_f,true>
-#define cdarray to_array<complex_d,true>
+#define fltarray convert_to_array<float,true>
+#define dblarray convert_to_array<double,true>
+#define intarray convert_to_array<int,true>
+#define bytearray convert_to_array<cbyte,true>
+#define cfarray convert_to_array<complex_f,true>
+#define cdarray convert_to_array<complex_d,true>
 
-#define Ifloat to_array<float,false>
-#define Idouble to_array<double,false>
-#define Iint to_array<int,false>
-#define Icomplex_f to_array<complex_f,false>
-#define Icomplex_d to_array<complex_d,false>
+#define Ifloat convert_to_array<float,false>
+#define Idouble convert_to_array<double,false>
+#define Iint convert_to_array<int,false>
+#define Icomplex_f convert_to_array<complex_f,false>
+#define Icomplex_d convert_to_array<complex_d,false>
 
 using namespace std;
 
@@ -61,7 +60,7 @@ using namespace std;
 //*****************************************************************************/
 
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-class to_array {
+class convert_to_array {
 
 public:
   typedef int (*TestIndexFunction)(int, int);
@@ -83,16 +82,16 @@ public:
   void set2ima() {if  (i_NbAxis == 2) is_ima=true;}
   void set2tab() {if  (i_NbAxis == 2) is_ima=false;}
 
-  to_array();
-  to_array (int pi_Nx, const char *Name);
-  to_array (int pi_Nx, int pi_Ny, const char *Name);
-  to_array (int pi_Nx, int pi_Ny, int pi_Nz, const char *Name);
-  to_array (int pi_Nx, int pi_Ny=0, int pi_Nz=0);
-  ~to_array ();
+  convert_to_array();
+  convert_to_array (int pi_Nx, const char *Name);
+  convert_to_array (int pi_Nx, int pi_Ny, const char *Name);
+  convert_to_array (int pi_Nx, int pi_Ny, int pi_Nz, const char *Name);
+  convert_to_array (int pi_Nx, int pi_Ny=0, int pi_Nz=0);
+  ~convert_to_array ();
   void free();
   PARAM_TYPE* buffer();
   PARAM_TYPE* const buffer() const;
-  void init (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat);
+  void init (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat);
   void init ();
   void init (PARAM_TYPE Val);
   void alloc (int pi_Nx, const char* Name=0);
@@ -122,13 +121,13 @@ public:
   inline PARAM_TYPE& operator[]  (int x, int y, int z) const;
   inline PARAM_TYPE & operator[]  (int x, int y, int z, type_border bord) const;
 */
-  const to_array<PARAM_TYPE,ARRAY_TYPE>& operator = (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat);
-  const to_array<PARAM_TYPE,ARRAY_TYPE>& operator += (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat);
-  const to_array<PARAM_TYPE,ARRAY_TYPE>& operator *= (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat);
-  const to_array<PARAM_TYPE,ARRAY_TYPE>& operator *= (const double coef);
-  const to_array<PARAM_TYPE,ARRAY_TYPE>& operator -= (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat);
-  const to_array<PARAM_TYPE,ARRAY_TYPE>& operator /= (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat);
-  const to_array<PARAM_TYPE,ARRAY_TYPE>& operator ^ (const double pf_coef);
+  const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& operator = (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat);
+  const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& operator += (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat);
+  const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& operator *= (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat);
+  const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& operator *= (const double coef);
+  const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& operator -= (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat);
+  const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& operator /= (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat);
+  const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& operator ^ (const double pf_coef);
 
   void info(string Name="");
   void display (int pi_NbElem=0);
@@ -165,7 +164,7 @@ public:
   void sigma_clip (float& pf_Mean, float& pf_Sigma, int pi_Nit=3) const;
   float sigma_clip (int pi_Nit=3) const;
 
-  to_array<PARAM_TYPE,ARRAY_TYPE> (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Obj);
+  convert_to_array<PARAM_TYPE,ARRAY_TYPE> (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Obj);
 
   inline void setBorder( type_border border )
   {
@@ -188,60 +187,60 @@ private:
 
 
 //------------------------------------------------------------------------------
-// to_array ()
+// convert_to_array ()
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE>::to_array () {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE>::convert_to_array () {
   set_attrib();
 }
 
 //------------------------------------------------------------------------------
-// to_array (int pi_Nx, const char* Name)
+// convert_to_array (int pi_Nx, const char* Name)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE>::to_array (int pi_Nx, const char* Name) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE>::convert_to_array (int pi_Nx, const char* Name) {
   set_attrib();
   alloc(pi_Nx, 0, 0, Name);
 }
 
 //------------------------------------------------------------------------------
-// to_array (int pi_Nx, int pi_Ny, const char* Name)
+// convert_to_array (int pi_Nx, int pi_Ny, const char* Name)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE>::to_array (int pi_Nx, int pi_Ny, const char* Name) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE>::convert_to_array (int pi_Nx, int pi_Ny, const char* Name) {
   set_attrib();
   alloc(pi_Nx, pi_Ny, 0, Name);
 }
 
 //------------------------------------------------------------------------------
-// to_array (int pi_Nx, int pi_Ny, int pi_Nz, const char* Name)
+// convert_to_array (int pi_Nx, int pi_Ny, int pi_Nz, const char* Name)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE>::to_array (int pi_Nx, int pi_Ny, int pi_Nz, const char* Name) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE>::convert_to_array (int pi_Nx, int pi_Ny, int pi_Nz, const char* Name) {
   set_attrib();
   alloc(pi_Nx, pi_Ny, pi_Nz, Name);
 }
 
 //------------------------------------------------------------------------------
-// to_array (int pi_Nx, int pi_Ny, int pi_Nz)
+// convert_to_array (int pi_Nx, int pi_Ny, int pi_Nz)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE>::to_array (int pi_Nx, int pi_Ny, int pi_Nz) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE>::convert_to_array (int pi_Nx, int pi_Ny, int pi_Nz) {
   set_attrib();
   alloc(pi_Nx, pi_Ny, pi_Nz);
 }
 
 //------------------------------------------------------------------------------
-// ~to_array ()
+// ~convert_to_array ()
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE>::~to_array () {free();}
+convert_to_array<PARAM_TYPE,ARRAY_TYPE>::~convert_to_array () {free();}
 
 //------------------------------------------------------------------------------
 // free ()
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-void to_array<PARAM_TYPE,ARRAY_TYPE>::free() {
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::free() {
   if (e_UseClassMemAlloc == true){
 #ifdef _USEMEM
     MemMg_free (po_Buffer);
@@ -258,7 +257,7 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::free() {
 // buffer ()
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-PARAM_TYPE* to_array<PARAM_TYPE,ARRAY_TYPE>::buffer() {
+PARAM_TYPE* convert_to_array<PARAM_TYPE,ARRAY_TYPE>::buffer() {
    return po_Buffer;
 }
 
@@ -266,7 +265,7 @@ PARAM_TYPE* to_array<PARAM_TYPE,ARRAY_TYPE>::buffer() {
 // buffer ()
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-PARAM_TYPE* const to_array<PARAM_TYPE,ARRAY_TYPE>::buffer() const {
+PARAM_TYPE* const convert_to_array<PARAM_TYPE,ARRAY_TYPE>::buffer() const {
    return po_Buffer;
 }
 
@@ -274,7 +273,7 @@ PARAM_TYPE* const to_array<PARAM_TYPE,ARRAY_TYPE>::buffer() const {
 // init ()
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-void to_array<PARAM_TYPE,ARRAY_TYPE>::init (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat) {
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::init (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat) {
    if (n_elem() != 0) free();
    if (ARRAY_TYPE==true) {
       alloc(pro_Mat.nx(), pro_Mat.ny(), pro_Mat.nz());
@@ -288,13 +287,13 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::init (const to_array<PARAM_TYPE,ARRAY_TYPE
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
 // !!!!! convert function from int to PARAM_TYPE must exist
-void to_array<PARAM_TYPE,ARRAY_TYPE>::init (PARAM_TYPE Val) {
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::init (PARAM_TYPE Val) {
    for (int i=0;i<n_elem();i++) po_Buffer[i] = Val;
 }
 
 template <class PARAM_TYPE, bool ARRAY_TYPE>
 // !!!!! convert function from int to PARAM_TYPE must exist
-void to_array<PARAM_TYPE,ARRAY_TYPE>::init ()
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::init ()
 {
    PARAM_TYPE Val=0;
    for (int i=0;i<n_elem();i++) po_Buffer[i] = Val;
@@ -303,7 +302,7 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::init ()
 // alloc (int pi_Nx, const char* Name)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-void to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (int pi_Nx, const char* Name) {
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (int pi_Nx, const char* Name) {
   alloc (pi_Nx, 0, 0, Name);
 }
 
@@ -311,7 +310,7 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (int pi_Nx, const char* Name) {
 // alloc (int pi_Nx, int pi_Ny, const char* Name)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-void to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (int pi_Nx, int pi_Ny, const char* Name) {
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (int pi_Nx, int pi_Ny, const char* Name) {
   alloc (pi_Nx, pi_Ny, 0, Name);
 }
 
@@ -319,7 +318,7 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (int pi_Nx, int pi_Ny, const char* N
 // alloc (int pi_Nx, int pi_Ny, int pi_Nz, const char* Name)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-void to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (int pi_Nx, int pi_Ny, int pi_Nz, const char* Name) {
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (int pi_Nx, int pi_Ny, int pi_Nz, const char* Name) {
 
   if (i_NbElem != 0) free();
 
@@ -376,7 +375,7 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (int pi_Nx, int pi_Ny, int pi_Nz, co
 // alloc (PARAM_TYPE *BuffData, int Nbr_Line, int Nbr_Col, const char *Name, bool MemManag)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-void to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (PARAM_TYPE *BuffData, int Nbr_Line, int Nbr_Col,
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (PARAM_TYPE *BuffData, int Nbr_Line, int Nbr_Col,
                                   const char *Name, bool MemManag) {
   if (i_NbElem != 0) {
     if (e_UseClassMemAlloc == true) {
@@ -405,7 +404,7 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (PARAM_TYPE *BuffData, int Nbr_Line,
 // alloc (PARAM_TYPE *BuffData, int Nx, int Ny, int Nz, const char *Name, bool MemManag)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-void to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (PARAM_TYPE *BuffData, int _Nx, int _Ny, int _Nz, const char *Name, bool MemManag)
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (PARAM_TYPE *BuffData, int _Nx, int _Ny, int _Nz, const char *Name, bool MemManag)
 {// doesnt work well, treated as an image
 	if (i_NbElem != 0)
 	{
@@ -433,7 +432,7 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::alloc (PARAM_TYPE *BuffData, int _Nx, int 
 // reform (const int pi_Nx, const int pi_Ny, const int pi_Nz)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-void to_array<PARAM_TYPE,ARRAY_TYPE>::reform (const int pi_Nx, const int pi_Ny,
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::reform (const int pi_Nx, const int pi_Ny,
                              const int pi_Nz) {
 
   if (i_NbElem == 0) alloc(pi_Nx,pi_Ny,pi_Nz,"alloc resize");
@@ -495,7 +494,7 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::reform (const int pi_Nx, const int pi_Ny,
 // resize (const int pi_Nx, const int pi_Ny=0, const int pi_Nz=0)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-void to_array<PARAM_TYPE,ARRAY_TYPE>::resize (const int pi_Nx, const int pi_Ny,
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::resize (const int pi_Nx, const int pi_Ny,
                              const int pi_Nz) {
    reform (pi_Nx,pi_Ny, pi_Nz);
 }
@@ -505,14 +504,14 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::resize (const int pi_Nx, const int pi_Ny,
 //------------------------------------------------------------------------------
 // could be used with 2d or 3d tab, on all the element.... => no border test...
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-inline PARAM_TYPE& to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x)  const {
+inline PARAM_TYPE& convert_to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x)  const {
    // if (naxis() != 1) {cout << "One dim array" << endl; exit(-1);}
 //!!!!!!!!!   assert (test_indice_i (tc_NameArray, x, nx()));
    return po_Buffer[x];
 }
 /*
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-inline PARAM_TYPE& to_array<PARAM_TYPE,ARRAY_TYPE>::operator[] (int x)  const {
+inline PARAM_TYPE& convert_to_array<PARAM_TYPE,ARRAY_TYPE>::operator[] (int x)  const {
    // if (naxis() != 1) {cout << "One dim array" << endl; exit(-1);}
 //!!!!!!!!!   assert (test_indice_i (tc_NameArray, x, nx()));
    return po_Buffer[x];
@@ -524,7 +523,7 @@ inline PARAM_TYPE& to_array<PARAM_TYPE,ARRAY_TYPE>::operator[] (int x)  const {
 //------------------------------------------------------------------------------
 // !!!!! convert function from int to PARAM_TYPE must exist
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-inline PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, type_border bord)  const {
+inline PARAM_TYPE convert_to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, type_border bord)  const {
 
   if (naxis() != 1)
   {
@@ -555,7 +554,7 @@ inline PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, type_borde
 
 
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-inline PARAM_TYPE & to_array<PARAM_TYPE,ARRAY_TYPE>::setx (int x, type_border bord)    {
+inline PARAM_TYPE & convert_to_array<PARAM_TYPE,ARRAY_TYPE>::setx (int x, type_border bord)    {
 
   if (naxis() != 1)
   {
@@ -589,7 +588,7 @@ inline PARAM_TYPE & to_array<PARAM_TYPE,ARRAY_TYPE>::setx (int x, type_border bo
 // operator (int x, int y)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-inline PARAM_TYPE& to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, int y) const {
+inline PARAM_TYPE& convert_to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, int y) const {
 #if CHECK_DIM
    if (i_NbAxis != 2)
    {
@@ -601,7 +600,7 @@ inline PARAM_TYPE& to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, int y) co
 }
 // specialization to the array case
 template <>
-inline float& to_array<float,true>::operator()(int x, int y) const
+inline float& convert_to_array<float,true>::operator()(int x, int y) const
 {
 #if CHECK_DIM
    if (i_NbAxis != 2)
@@ -613,7 +612,7 @@ inline float& to_array<float,true>::operator()(int x, int y) const
    return po_Buffer[y*pto_TabNaxis[0]+x];
 }
 template <>
-inline double& to_array<double,true>::operator()(int x, int y) const
+inline double& convert_to_array<double,true>::operator()(int x, int y) const
 {
 #if CHECK_DIM
    if (i_NbAxis != 2)
@@ -625,7 +624,7 @@ inline double& to_array<double,true>::operator()(int x, int y) const
    return po_Buffer[y*pto_TabNaxis[0]+x];
 }
 template <>
-inline int& to_array<int,true>::operator()(int x, int y) const
+inline int& convert_to_array<int,true>::operator()(int x, int y) const
 {
 #if CHECK_DIM
    if (i_NbAxis != 2)
@@ -637,7 +636,7 @@ inline int& to_array<int,true>::operator()(int x, int y) const
    return po_Buffer[y*pto_TabNaxis[0]+x];
 }
 template <>
-inline cbyte& to_array<cbyte,true>::operator()(int x, int y) const
+inline cbyte& convert_to_array<cbyte,true>::operator()(int x, int y) const
 {
 #if CHECK_DIM
    if (i_NbAxis != 2)
@@ -649,7 +648,7 @@ inline cbyte& to_array<cbyte,true>::operator()(int x, int y) const
    return po_Buffer[y*pto_TabNaxis[0]+x];
 }
 template <>
-inline complex_f& to_array<complex_f,true>::operator()(int x, int y) const
+inline complex_f& convert_to_array<complex_f,true>::operator()(int x, int y) const
 {
 #if CHECK_DIM
    if (i_NbAxis != 2)
@@ -661,7 +660,7 @@ inline complex_f& to_array<complex_f,true>::operator()(int x, int y) const
    return po_Buffer[y*pto_TabNaxis[0]+x];
 }
 template <>
-inline complex_d& to_array<complex_d,true>::operator()(int x, int y) const
+inline complex_d& convert_to_array<complex_d,true>::operator()(int x, int y) const
 {
 #if CHECK_DIM
    if (i_NbAxis != 2)
@@ -678,7 +677,7 @@ inline complex_d& to_array<complex_d,true>::operator()(int x, int y) const
 //------------------------------------------------------------------------------
 
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-inline PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, int y, type_border bord) const
+inline PARAM_TYPE convert_to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, int y, type_border bord) const
 {
 #if CHECK_DIM
   if (i_NbAxis != 2)
@@ -693,7 +692,7 @@ inline PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, int y, typ
 }
 // specialization to the array case
 template <>
-inline float to_array<float,true>::operator()(int x, int y, type_border bord) const
+inline float convert_to_array<float,true>::operator()(int x, int y, type_border bord) const
 {
 #if CHECK_DIM
    if (i_NbAxis != 2)
@@ -707,7 +706,7 @@ inline float to_array<float,true>::operator()(int x, int y, type_border bord) co
    return po_Buffer[indy*pto_TabNaxis[0]+indx];
 }
 template <>
-inline double to_array<double,true>::operator()(int x, int y, type_border bord) const
+inline double convert_to_array<double,true>::operator()(int x, int y, type_border bord) const
 {
 #if CHECK_DIM
    if (i_NbAxis != 2)
@@ -721,7 +720,7 @@ inline double to_array<double,true>::operator()(int x, int y, type_border bord) 
    return po_Buffer[indy*pto_TabNaxis[0]+indx];
 }
 template <>
-inline int to_array<int,true>::operator()(int x, int y, type_border bord) const
+inline int convert_to_array<int,true>::operator()(int x, int y, type_border bord) const
 {
 #if CHECK_DIM
    if (i_NbAxis != 2)
@@ -735,7 +734,7 @@ inline int to_array<int,true>::operator()(int x, int y, type_border bord) const
    return po_Buffer[indy*pto_TabNaxis[0]+indx];
 }
 template <>
-inline cbyte to_array<cbyte,true>::operator()(int x, int y, type_border bord) const
+inline cbyte convert_to_array<cbyte,true>::operator()(int x, int y, type_border bord) const
 {
 #if CHECK_DIM
    if (i_NbAxis != 2)
@@ -749,7 +748,7 @@ inline cbyte to_array<cbyte,true>::operator()(int x, int y, type_border bord) co
    return po_Buffer[indy*pto_TabNaxis[0]+indx];
 }
 template <>
-inline complex_f to_array<complex_f,true>::operator()(int x, int y, type_border bord) const
+inline complex_f convert_to_array<complex_f,true>::operator()(int x, int y, type_border bord) const
 {
 #if CHECK_DIM
    if (i_NbAxis != 2)
@@ -763,7 +762,7 @@ inline complex_f to_array<complex_f,true>::operator()(int x, int y, type_border 
    return po_Buffer[indy*pto_TabNaxis[0]+indx];
 }
 template <>
-inline complex_d to_array<complex_d,true>::operator()(int x, int y, type_border bord) const
+inline complex_d convert_to_array<complex_d,true>::operator()(int x, int y, type_border bord) const
 {
 #if CHECK_DIM
    if (i_NbAxis != 2)
@@ -779,7 +778,7 @@ inline complex_d to_array<complex_d,true>::operator()(int x, int y, type_border 
 
 
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-inline PARAM_TYPE & to_array<PARAM_TYPE,ARRAY_TYPE>::setxy (int x, int y, type_border bord)    {
+inline PARAM_TYPE & convert_to_array<PARAM_TYPE,ARRAY_TYPE>::setxy (int x, int y, type_border bord)    {
 
  if (naxis() != 2)
   {
@@ -844,7 +843,7 @@ inline PARAM_TYPE & to_array<PARAM_TYPE,ARRAY_TYPE>::setxy (int x, int y, type_b
 // operator (int x, int y, int z)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-inline PARAM_TYPE& to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, int y, int z) const {
+inline PARAM_TYPE& convert_to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, int y, int z) const {
 #if CHECK_DIM
    if (naxis() != 3)
    {
@@ -861,7 +860,7 @@ inline PARAM_TYPE& to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, int y, in
 //------------------------------------------------------------------------------
 
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-inline PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, int y, int z, type_border bord) const {
+inline PARAM_TYPE convert_to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, int y, int z, type_border bord) const {
 #if CHECK_DIM
   if (naxis() != 3)
   {
@@ -898,7 +897,7 @@ inline PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::operator() (int x, int y, int
 
 
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-inline PARAM_TYPE & to_array<PARAM_TYPE,ARRAY_TYPE>::setxyz (int x, int y, int z, type_border bord)    {
+inline PARAM_TYPE & convert_to_array<PARAM_TYPE,ARRAY_TYPE>::setxyz (int x, int y, int z, type_border bord)    {
 #if CHECK_DIM
   if (naxis() != 3)
   {
@@ -942,7 +941,7 @@ inline PARAM_TYPE & to_array<PARAM_TYPE,ARRAY_TYPE>::setxyz (int x, int y, int z
 // operator =
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE> const
-to_array<PARAM_TYPE,ARRAY_TYPE>& to_array<PARAM_TYPE,ARRAY_TYPE>::operator = (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat)
+convert_to_array<PARAM_TYPE,ARRAY_TYPE>& convert_to_array<PARAM_TYPE,ARRAY_TYPE>::operator = (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat)
 {
   reform (pro_Mat.n_elem());
 #ifdef _OPENMP
@@ -963,7 +962,7 @@ to_array<PARAM_TYPE,ARRAY_TYPE>& to_array<PARAM_TYPE,ARRAY_TYPE>::operator = (co
 // operator +=
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE> const
-to_array<PARAM_TYPE,ARRAY_TYPE>& to_array<PARAM_TYPE,ARRAY_TYPE>::operator += (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE>& convert_to_array<PARAM_TYPE,ARRAY_TYPE>::operator += (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat) {
   for (int x=0; x<i_NbElem; x++) po_Buffer[x] += pro_Mat.po_Buffer[x];
   return (*this);
 }
@@ -972,7 +971,7 @@ to_array<PARAM_TYPE,ARRAY_TYPE>& to_array<PARAM_TYPE,ARRAY_TYPE>::operator += (c
 // operator *=
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE> const
-to_array<PARAM_TYPE,ARRAY_TYPE>& to_array<PARAM_TYPE,ARRAY_TYPE>::operator *= (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE>& convert_to_array<PARAM_TYPE,ARRAY_TYPE>::operator *= (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat) {
   for (int x=0; x<i_NbElem; x++) po_Buffer[x] *= pro_Mat.po_Buffer[x];
   return (*this);
 }
@@ -981,7 +980,7 @@ to_array<PARAM_TYPE,ARRAY_TYPE>& to_array<PARAM_TYPE,ARRAY_TYPE>::operator *= (c
 // operator *=
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE> const
-to_array<PARAM_TYPE,ARRAY_TYPE>& to_array<PARAM_TYPE,ARRAY_TYPE>::operator *= (const double coef) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE>& convert_to_array<PARAM_TYPE,ARRAY_TYPE>::operator *= (const double coef) {
   for (int i=0; i<i_NbElem; i++)
     po_Buffer[i] = (PARAM_TYPE) ((double)po_Buffer[i] * coef);
   return (*this);
@@ -991,7 +990,7 @@ to_array<PARAM_TYPE,ARRAY_TYPE>& to_array<PARAM_TYPE,ARRAY_TYPE>::operator *= (c
 // operator -=
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE> const
-to_array<PARAM_TYPE,ARRAY_TYPE>& to_array<PARAM_TYPE,ARRAY_TYPE>::operator -= (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat)
+convert_to_array<PARAM_TYPE,ARRAY_TYPE>& convert_to_array<PARAM_TYPE,ARRAY_TYPE>::operator -= (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat)
 {
 #ifdef _OPENMP
   #pragma omp parallel for
@@ -1009,7 +1008,7 @@ to_array<PARAM_TYPE,ARRAY_TYPE>& to_array<PARAM_TYPE,ARRAY_TYPE>::operator -= (c
 // operator /=
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE> const
-to_array<PARAM_TYPE,ARRAY_TYPE>& to_array<PARAM_TYPE,ARRAY_TYPE>::operator /= (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE>& convert_to_array<PARAM_TYPE,ARRAY_TYPE>::operator /= (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Mat) {
   for (int x=0; x<i_NbElem; x++)
      if ((pro_Mat.po_Buffer[x] > 1e-07) || (pro_Mat.po_Buffer[x] < -1e-07))
         po_Buffer[x] /= pro_Mat.po_Buffer[x];
@@ -1022,7 +1021,7 @@ to_array<PARAM_TYPE,ARRAY_TYPE>& to_array<PARAM_TYPE,ARRAY_TYPE>::operator /= (c
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE> const
 // !!!!! convert function from PARAM_TYPE to double must exist
-to_array<PARAM_TYPE,ARRAY_TYPE>& to_array<PARAM_TYPE,ARRAY_TYPE>::operator ^ (const double pf_coef) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE>& convert_to_array<PARAM_TYPE,ARRAY_TYPE>::operator ^ (const double pf_coef) {
   for (int i=0; i<i_NbElem; i++)
     po_Buffer[i] = (PARAM_TYPE) pow ((double)po_Buffer[i], pf_coef);
   return (*this);
@@ -1033,7 +1032,7 @@ to_array<PARAM_TYPE,ARRAY_TYPE>& to_array<PARAM_TYPE,ARRAY_TYPE>::operator ^ (co
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
 // !!!!! PARAM_TYPE must accept operator << !!!!!!!!!!!
-void to_array<PARAM_TYPE,ARRAY_TYPE>::info(string Name) {
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::info(string Name) {
   if (Name=="") cout << "   :" ;
   else cout << "  " << Name;
   cout << ", mean = " << mean() << ", sigma = " << sigma();
@@ -1045,7 +1044,7 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::info(string Name) {
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
 // !!!!! PARAM_TYPE must accept operator << !!!!!!!!!!!
-void to_array<PARAM_TYPE,ARRAY_TYPE>::display (int pi_NbElem) {
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::display (int pi_NbElem) {
   if (pi_NbElem == 0) {
        cout <<"  nx="<<pto_TabNaxis[0]<<", ny="<<pto_TabNaxis[1]<<
               ", nz="<<pto_TabNaxis[2]<<", naxis="<<i_NbAxis<<endl;
@@ -1064,7 +1063,7 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::display (int pi_NbElem) {
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
 // !!!!! convert function from int to PARAM_TYPE must exist
-void to_array<PARAM_TYPE,ARRAY_TYPE>::rampgen() {
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::rampgen() {
   for (int i=0;i<i_NbElem;i++) po_Buffer[i]=(PARAM_TYPE)i;
 }
 
@@ -1072,21 +1071,21 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::rampgen() {
 // line()
 //------------------------------------------------------------------------------
 //template <class PARAM_TYPE, bool ARRAY_TYPE>
-//to_array<PARAM_TYPE,ARRAY_TYPE> to_array<PARAM_TYPE,ARRAY_TYPE>::line (int i) {
+//convert_to_array<PARAM_TYPE,ARRAY_TYPE> convert_to_array<PARAM_TYPE,ARRAY_TYPE>::line (int i) {
 //}
 
 //------------------------------------------------------------------------------
 // column()
 //------------------------------------------------------------------------------
 //template <class PARAM_TYPE, bool ARRAY_TYPE>
-//to_array<PARAM_TYPE,ARRAY_TYPE> to_array<PARAM_TYPE,ARRAY_TYPE>::column (int j) {
+//convert_to_array<PARAM_TYPE,ARRAY_TYPE> convert_to_array<PARAM_TYPE,ARRAY_TYPE>::column (int j) {
 //}
 
 //------------------------------------------------------------------------------
 // sup_threshold (float ThresholLevel)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-void to_array<PARAM_TYPE,ARRAY_TYPE>::sup_threshold (float ThresholLevel) {
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::sup_threshold (float ThresholLevel) {
   for (int x=0;x<i_NbElem;x++)
     if ((PARAM_TYPE)po_Buffer[x] > ThresholLevel)
       po_Buffer[x] = (PARAM_TYPE)ThresholLevel;
@@ -1097,7 +1096,7 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::sup_threshold (float ThresholLevel) {
 // inf_threshold (float ThresholLevel)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-void to_array<PARAM_TYPE,ARRAY_TYPE>::inf_threshold (float ThresholLevel) {
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::inf_threshold (float ThresholLevel) {
   for (int x=0;x<i_NbElem;x++)
     if ((PARAM_TYPE)po_Buffer[x] < ThresholLevel)
       po_Buffer[x] = (PARAM_TYPE)ThresholLevel;
@@ -1107,7 +1106,7 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::inf_threshold (float ThresholLevel) {
 // min ()
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::min () {
+PARAM_TYPE convert_to_array<PARAM_TYPE,ARRAY_TYPE>::min () {
   int ai_temp=0;
   return (min (ai_temp));
 }
@@ -1116,7 +1115,7 @@ PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::min () {
 // min (int& pri_ind)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::min (int& pri_ind) {
+PARAM_TYPE convert_to_array<PARAM_TYPE,ARRAY_TYPE>::min (int& pri_ind) {
   PARAM_TYPE ao_prov=po_Buffer[0];
   pri_ind=0;
   for (int i=1; i<i_NbElem; i++)
@@ -1131,7 +1130,7 @@ PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::min (int& pri_ind) {
 // max ()
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::max () {
+PARAM_TYPE convert_to_array<PARAM_TYPE,ARRAY_TYPE>::max () {
   int ai_temp=0;
   return (max (ai_temp));
 }
@@ -1141,7 +1140,7 @@ PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::max () {
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
 //!!!!!!!!!! PARAM_TYPE must define operator <...
-PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::max (int& pri_ind) {
+PARAM_TYPE convert_to_array<PARAM_TYPE,ARRAY_TYPE>::max (int& pri_ind) {
   PARAM_TYPE ao_prov=po_Buffer[0];
   pri_ind=0;
   for (int i=1; i<i_NbElem; i++)
@@ -1156,7 +1155,7 @@ PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::max (int& pri_ind) {
 // maxfabs ()
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::maxfabs () {
+PARAM_TYPE convert_to_array<PARAM_TYPE,ARRAY_TYPE>::maxfabs () {
   int ai_temp=0;
   return (maxfabs (ai_temp));
 }
@@ -1166,7 +1165,7 @@ PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::maxfabs () {
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
 //!!!!!!!!!! PARAM_TYPE must define operator <...
-PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::maxfabs (int& pri_ind) {
+PARAM_TYPE convert_to_array<PARAM_TYPE,ARRAY_TYPE>::maxfabs (int& pri_ind) {
   PARAM_TYPE ao_prov=0;
   pri_ind=0;
   for (int i=0; i<i_NbElem; i++)
@@ -1182,7 +1181,7 @@ PARAM_TYPE to_array<PARAM_TYPE,ARRAY_TYPE>::maxfabs (int& pri_ind) {
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
 // !!!!! convert function from PARAM_TYPE to double must exist
-double to_array<PARAM_TYPE,ARRAY_TYPE>::total () const {
+double convert_to_array<PARAM_TYPE,ARRAY_TYPE>::total () const {
   double ao_prov= 0.;
   for (int i=0; i<i_NbElem; i++) ao_prov += po_Buffer[i];
   return ao_prov;
@@ -1193,7 +1192,7 @@ double to_array<PARAM_TYPE,ARRAY_TYPE>::total () const {
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
 // !!!!! convert function from PARAM_TYPE to double must exist
-double to_array<PARAM_TYPE,ARRAY_TYPE>::energy () const {
+double convert_to_array<PARAM_TYPE,ARRAY_TYPE>::energy () const {
   PARAM_TYPE ao_prov=(PARAM_TYPE)0;
   for (int i=0; i<i_NbElem; i++) ao_prov += po_Buffer[i]*po_Buffer[i];
   return ao_prov;
@@ -1204,7 +1203,7 @@ double to_array<PARAM_TYPE,ARRAY_TYPE>::energy () const {
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
 // !!!!! convert function from PARAM_TYPE to double must exist
-double to_array<PARAM_TYPE,ARRAY_TYPE>::sigma () const {
+double convert_to_array<PARAM_TYPE,ARRAY_TYPE>::sigma () const {
   double ao_moy = mean();
   double ad_sigma=0., ad_val=0;
   for (int i=0; i<i_NbElem; i++) {
@@ -1221,7 +1220,7 @@ double to_array<PARAM_TYPE,ARRAY_TYPE>::sigma () const {
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
 // !!!!! convert function from PARAM_TYPE to double must exist
-double to_array<PARAM_TYPE,ARRAY_TYPE>::mean () const {
+double convert_to_array<PARAM_TYPE,ARRAY_TYPE>::mean () const {
   return (double(total())/i_NbElem);
 }
 
@@ -1230,7 +1229,7 @@ double to_array<PARAM_TYPE,ARRAY_TYPE>::mean () const {
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
 // !!!!! convert function from PARAM_TYPE to double must exist
-void to_array<PARAM_TYPE,ARRAY_TYPE>::sigma_clip (float& pf_Mean, float &pf_Sigma,
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::sigma_clip (float& pf_Mean, float &pf_Sigma,
                                        int pi_Nit) const {
 
   double ad_s0, ad_s1, ad_s2, ad_sm=0., ad_inter;
@@ -1256,18 +1255,18 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::sigma_clip (float& pf_Mean, float &pf_Sigm
 // sigma_clip (int pi_Nit)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-float to_array<PARAM_TYPE,ARRAY_TYPE>::sigma_clip (int pi_Nit) const {
+float convert_to_array<PARAM_TYPE,ARRAY_TYPE>::sigma_clip (int pi_Nit) const {
   float af_Mean=0., af_Sigma=0.;
   sigma_clip (af_Mean, af_Sigma, pi_Nit);
   return (af_Sigma);
 }
 
 //------------------------------------------------------------------------------
-// to_array (to_array&)
+// convert_to_array (convert_to_array&)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE>::to_array
-  (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Obj) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE>::convert_to_array
+  (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_Obj) {
   i_NbElem=0;
   if (ARRAY_TYPE==true) {
      alloc (pro_Obj.nx(), pro_Obj.ny(), pro_Obj.nz());
@@ -1281,7 +1280,7 @@ to_array<PARAM_TYPE,ARRAY_TYPE>::to_array
 // set_attrib (int pi_Nit)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-void to_array<PARAM_TYPE,ARRAY_TYPE>::set_attrib () {
+void convert_to_array<PARAM_TYPE,ARRAY_TYPE>::set_attrib () {
   po_Buffer = (PARAM_TYPE*)NULL;
   i_NbElem = 0;
   i_NbAxis = 0;
@@ -1298,129 +1297,129 @@ void to_array<PARAM_TYPE,ARRAY_TYPE>::set_attrib () {
 }
 
 //------------------------------------------------------------------------------
-// operator + (to_array, to_array)
+// operator + (convert_to_array, convert_to_array)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE> operator + (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj1,
-                           const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj2) {
-  //to_array<PARAM_TYPE,ARRAY_TYPE>* apo_array = new to_array<PARAM_TYPE,ARRAY_TYPE>;
-  to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
+convert_to_array<PARAM_TYPE,ARRAY_TYPE> operator + (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj1,
+                           const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj2) {
+  //convert_to_array<PARAM_TYPE,ARRAY_TYPE>* apo_array = new convert_to_array<PARAM_TYPE,ARRAY_TYPE>;
+  convert_to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
   //apo_array->init(pro_obj1);
   ao_array.init(pro_obj1);
   for (int i=0; i<pro_obj1.n_elem(); i++)
     ao_array(i) = pro_obj1(i) + pro_obj2(i);
     //(*apo_array)(i) = pro_obj1(i) + pro_obj2(i);
-  return (to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
+  return (convert_to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
 }
 
 //------------------------------------------------------------------------------
-// operator - (to_array, to_array)
+// operator - (convert_to_array, convert_to_array)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE> operator - (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj1,
-                           const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj2) {
-  to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
+convert_to_array<PARAM_TYPE,ARRAY_TYPE> operator - (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj1,
+                           const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj2) {
+  convert_to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
   ao_array.init(pro_obj1);
   for (int i=0; i<pro_obj1.n_elem(); i++)
     ao_array(i)  = pro_obj1(i) - pro_obj2(i);
-  return (to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
+  return (convert_to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
 }
 
 //------------------------------------------------------------------------------
-// operator * (to_array, to_array)
+// operator * (convert_to_array, convert_to_array)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE> operator * (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj1,
-                           const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj2) {
-  to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
+convert_to_array<PARAM_TYPE,ARRAY_TYPE> operator * (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj1,
+                           const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj2) {
+  convert_to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
   ao_array.init(pro_obj1);
   for (int i=0; i<pro_obj1.n_elem(); i++)
     ao_array(i) = pro_obj1(i) * pro_obj2(i);
-  return (to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
+  return (convert_to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
 }
 
 //------------------------------------------------------------------------------
-// operator / (to_array, to_array)
+// operator / (convert_to_array, convert_to_array)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE> operator / (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj1,
-                           const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj2) {
-  to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
+convert_to_array<PARAM_TYPE,ARRAY_TYPE> operator / (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj1,
+                           const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj2) {
+  convert_to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
   ao_array.init(pro_obj1);
   for (int i=0; i<pro_obj1.n_elem(); i++)
     if ((pro_obj2(i) > 1e-07) || (pro_obj2(i) < -1e-07))
       ao_array(i) = pro_obj1(i) / pro_obj2(i);
     else ao_array(i) = 0;
-  return (to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
+  return (convert_to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
 }
 
 
 //------------------------------------------------------------------------------
-// operator * (double , to_array)
+// operator * (double , convert_to_array)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE> operator * (const double mult_coeff,
-											const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj) {
-	to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
+convert_to_array<PARAM_TYPE,ARRAY_TYPE> operator * (const double mult_coeff,
+											const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj) {
+	convert_to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
 	ao_array.init(pro_obj);
 	for (int i=0; i<pro_obj.nx(); i++)
 		ao_array(i)=mult_coeff*pro_obj(i);
-	return (to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
+	return (convert_to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
 }
 //------------------------------------------------------------------------------
-// operator / (to_array,double)
+// operator / (convert_to_array,double)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE> operator / (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj,
+convert_to_array<PARAM_TYPE,ARRAY_TYPE> operator / (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj,
 											const double div_coeff)
 {
-	to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
+	convert_to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
 	ao_array.init(pro_obj);
 	for (int i=0; i<pro_obj.nx(); i++)
 		ao_array(i)=pro_obj(i)/div_coeff;
-	return (to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
+	return (convert_to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
 }
 
 //------------------------------------------------------------------------------
-// operator > (to_array,double)
+// operator > (convert_to_array,double)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE> operator > (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj,
+convert_to_array<PARAM_TYPE,ARRAY_TYPE> operator > (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj,
 											const double bound_coeff) {
-	to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
+	convert_to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
 	ao_array.init(pro_obj);
 	for (long int i=0; i<pro_obj.nx(); i++)
 		if(pro_obj(i) > bound_coeff) ao_array(i)=1.0;
 		else ao_array(i)=0.0;
-	return (to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
+	return (convert_to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
 }
 
 //------------------------------------------------------------------------------
-// operator < (to_array,double)
+// operator < (convert_to_array,double)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE> operator < (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj,
+convert_to_array<PARAM_TYPE,ARRAY_TYPE> operator < (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj,
 											const double bound_coeff) {
-	to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
+	convert_to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
 	ao_array.init(pro_obj);
 	for (long int i=0; i<pro_obj.nx(); i++)
 		if(pro_obj(i) < bound_coeff) ao_array(i)=1.0;
 		else ao_array(i)=0.0;
-	return (to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
+	return (convert_to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
 }
 
 //------------------------------------------------------------------------------
-// mult (to_array,to_array)
+// mult (convert_to_array,convert_to_array)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE> mult (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj1,
-											const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj2) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE> mult (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj1,
+											const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj2) {
 	if(pro_obj1.ny() != pro_obj2.nx())
 	{
 		printf("Can't multiply: 1st matrix number of columns different from 2nd matrix number of rows. \n");
 		exit(-1);
 	}
-	to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
+	convert_to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
 	if(pro_obj2.ny()>0)
 	{
 		ao_array.alloc(pro_obj1.nx(),pro_obj2.ny());
@@ -1444,16 +1443,16 @@ to_array<PARAM_TYPE,ARRAY_TYPE> mult (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro
 				ao_array(i) += pro_obj1(i,k) * pro_obj2(k);
 		}
 	}
-    return (to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
+    return (convert_to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
 }
 
 //------------------------------------------------------------------------------
-// transpose (to_array)
+// transpose (convert_to_array)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE> transpose (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE> transpose (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj) {
 
-	to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
+	convert_to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
 	ao_array.alloc(pro_obj.ny(),pro_obj.nx());
 	for(int i=0;i<pro_obj.nx();i++)
 	{
@@ -1462,43 +1461,43 @@ to_array<PARAM_TYPE,ARRAY_TYPE> transpose (const to_array<PARAM_TYPE,ARRAY_TYPE>
 			ao_array(j,i)=pro_obj(i,j);
 		}
 	}
-	return (to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
+	return (convert_to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
 }
 
 
 //------------------------------------------------------------------------------
-// invert (to_array)
+// invert (convert_to_array)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE> invert (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE> invert (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj) {
 	if(pro_obj.nx() !=2 || pro_obj.ny()!=2)
 	{
 		printf("Matrix must be 2x2 to be inverted. \n");
 		exit(-1);
 	}
-	to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
+	convert_to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
 	ao_array.alloc(2,2);
 	double det=pro_obj(0,0)*pro_obj(1,1)-pro_obj(0,1)*pro_obj(1,0);
 	ao_array(0,0)=1/det*pro_obj(1,1);
 	ao_array(1,1)=1/det*pro_obj(0,0);
 	ao_array(0,1)=-1/det*pro_obj(0,1);
 	ao_array(1,0)=-1/det*pro_obj(1,0);
-    return (to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
+    return (convert_to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
 }
 
 //------------------------------------------------------------------------------
-// mult (to_array,to_array, int)
+// mult (convert_to_array,convert_to_array, int)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE> mult (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj1,
-									  const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj2, int index_z) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE> mult (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj1,
+									  const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj2, int index_z) {
 	if(index_z >= pro_obj1.nz()) printf("Wrong z index. \n");
 	if(pro_obj1.ny() != pro_obj2.nx())
 	{
 		printf("Can't multiply: 1st matrix number of columns different from 2nd matrix number of rows. \n");
 		exit(-1);
 	}
-	to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
+	convert_to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
 	if(pro_obj2.ny()>0)
 	{
 		ao_array.alloc(pro_obj1.nx(),pro_obj2.ny());
@@ -1522,23 +1521,23 @@ to_array<PARAM_TYPE,ARRAY_TYPE> mult (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro
 				ao_array(i) += pro_obj1(i,k,index_z) * pro_obj2(k);
 		}
 	}
-    return (to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
+    return (convert_to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
 }
 
 //------------------------------------------------------------------------------
-// log (to_array)
+// log (convert_to_array)
 //------------------------------------------------------------------------------
 template <class PARAM_TYPE, bool ARRAY_TYPE>
-to_array<PARAM_TYPE,ARRAY_TYPE> log (const to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj) {
+convert_to_array<PARAM_TYPE,ARRAY_TYPE> log (const convert_to_array<PARAM_TYPE,ARRAY_TYPE>& pro_obj) {
 
-	to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
+	convert_to_array<PARAM_TYPE,ARRAY_TYPE> ao_array;
 	ao_array.alloc(pro_obj.nx(),pro_obj.ny(),pro_obj.nz());
 	for(int i=0;i<pro_obj.nx();i++)
 		for(int j=0;j<pro_obj.ny();j++)
 			for(int k=0;k<pro_obj.nz();k++)
 				ao_array(i,j,k)=log(pro_obj(i,j,k));
 
-    return (to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
+    return (convert_to_array<PARAM_TYPE,ARRAY_TYPE>(ao_array));
 }
 
 


### PR DESCRIPTION
- Updated C++ standard to 20
- Updated Pybind11 version to 2.13.6
- Renamed `to_array` to `convert_to_array` to avoid conflict with > C++17 std namespace, need to compile with Apple Clang v17